### PR TITLE
Scanner metadata bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tags
 /backend/yoyo.ini
 /data/
 /scripts/
+.vscode

--- a/backend/src/indexer/scanner.py
+++ b/backend/src/indexer/scanner.py
@@ -258,7 +258,8 @@ def insert_into_genre_collections(
     :param genres: The genre tags from the track.
     :param cursor: A cursor to the database.
     """
-    for genre in chain(*[_split_genres(g) for g in genres]):
+    flattened_genres_itr = chain(*[_split_genres(g) for g in genres])
+    for genre in uniq_list(flattened_genres_itr):
         if not genre:
             continue
 

--- a/backend/src/indexer/scanner.py
+++ b/backend/src/indexer/scanner.py
@@ -258,8 +258,7 @@ def insert_into_genre_collections(
     :param genres: The genre tags from the track.
     :param cursor: A cursor to the database.
     """
-    flattened_genres_itr = chain(*[_split_genres(g) for g in genres])
-    for genre in uniq_list(flattened_genres_itr):
+    for genre in uniq_list(chain(*[_split_genres(g) for g in genres])):
         if not genre:
             continue
 

--- a/backend/tests/indexer/test_scanner.py
+++ b/backend/tests/indexer/test_scanner.py
@@ -252,11 +252,22 @@ def test_insert_into_label_collection_new(db):
 
 def test_insert_into_genre_collections(db):
     rls = release.from_id(1, db)
-    insert_into_genre_collections(rls, ["1, 2, 3", "2/3", "4; 5"], db)
+    insert_into_genre_collections(rls, ["1, 2, 3", "4; 5"], db)
 
     collections = release.collections(rls, db)
 
     for genre in ["1", "2", "3", "4", "5"]:
+        col = collection.from_name_and_type(genre, CollectionType.GENRE, db)
+        assert col in collections
+
+
+def test_duplicate_genre(db):
+    rls = release.from_id(1, db)
+    insert_into_genre_collections(rls, ["1, 2, 3", "2/3"], db)
+
+    collections = release.collections(rls, db)
+
+    for genre in ["1", "2", "3"]:
         col = collection.from_name_and_type(genre, CollectionType.GENRE, db)
         assert col in collections
 

--- a/backend/tests/indexer/test_scanner.py
+++ b/backend/tests/indexer/test_scanner.py
@@ -252,7 +252,7 @@ def test_insert_into_label_collection_new(db):
 
 def test_insert_into_genre_collections(db):
     rls = release.from_id(1, db)
-    insert_into_genre_collections(rls, ["1, 2, 3", "4; 5"], db)
+    insert_into_genre_collections(rls, ["1, 2, 3", "2/3", "4; 5"], db)
 
     collections = release.collections(rls, db)
 


### PR DESCRIPTION
Fix an issue where duplicate genres would be created after regex splitting genre tags. This caused the library index to fail.