### PR TITLE
Per user inbox & favorites and personal collections/playlists

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -89,10 +89,14 @@ CREATE TABLE music__collections (
     name VARCHAR COLLATE 'NOCASE' NOT NULL,
     starred BOOLEAN NOT NULL DEFAULT 0 CHECK (starred IN (0, 1)),
     type INTEGER NOT NULL,
+    user_id INTEGER,
     last_updated_on TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (type) REFERENCES music__collection_types__enum(id),
-    UNIQUE (name, type)
+    FOREIGN KEY (user_id) REFERENCES system__users(id) ON DELETE CASCADE,
+    UNIQUE (name, type, user_id),
+    -- Assert that all System & Personal collections have a user ID attached.
+    CHECK (type NOT IN (1, 2) OR user_id IS NOT NULL)
 );
 
 CREATE INDEX music__collections__sorting__idx
@@ -119,10 +123,14 @@ CREATE TABLE music__playlists (
     name VARCHAR COLLATE 'NOCASE' NOT NULL,
     starred BOOLEAN NOT NULL DEFAULT 0 CHECK (starred IN (0, 1)),
     type INTEGER NOT NULL,
+    user_id INTEGER,
     last_updated_on TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (type) REFERENCES music__playlist_types__enum(id),
-    UNIQUE (name, type)
+    FOREIGN KEY (user_id) REFERENCES system__users(id) ON DELETE CASCADE,
+    UNIQUE (name, type, user_id),
+    -- Assert that all System & Personal playlists have a user ID attached.
+    CHECK (type NOT IN (1, 2) OR user_id IS NOT NULL)
 );
 
 CREATE INDEX music__playlists__sorting__idx

--- a/backend/src/cli/config.py
+++ b/backend/src/cli/config.py
@@ -1,19 +1,18 @@
 import click
 
 from src.cli.commands import commands, shared_options
-from src.constants import Constants
+from src.constants import constants
 
 
 @commands.command()
 @shared_options
 def config():
     """Edit the application config."""
-    cons = Constants()
-    with cons.config_path.open("r") as fp:
+    with constants.config_path.open("r") as fp:
         config_contents = fp.read()
 
     config_contents = click.edit(config_contents, extension=".ini")
 
     if config_contents:
-        with cons.config_path.open("w+") as fp:
+        with constants.config_path.open("w+") as fp:
             fp.write(config_contents)

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -2,11 +2,11 @@ import json
 import logging
 from configparser import ConfigParser
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from huey import crontab
 
-from src.constants import Constants
+from src.constants import constants
 from src.errors import InvalidConfig
 from src.util import parse_crontab
 
@@ -24,8 +24,7 @@ def initialize_config():
     """
     Write the default config to the constant `config_path` location.
     """
-    cons = Constants()
-    write_default_config(cons.config_path)
+    write_default_config(constants.config_path)
 
 
 def write_default_config(config_path: Path) -> None:
@@ -72,8 +71,7 @@ class _Config:
     """
 
     def __init__(self):
-        cons = Constants()
-        self.parser = _load_config(cons.config_path)
+        self.parser = _load_config(constants.config_path)
 
     @property
     def music_directories(self) -> list[str]:
@@ -84,8 +82,9 @@ class _Config:
                 "repertoire.music_directories is not a valid JSON-encoded list."
             )
 
+    # TODO: Type
     @property
-    def index_crontab(self) -> int:
+    def index_crontab(self) -> Any:
         try:
             return crontab(**parse_crontab(self.parser["repertoire"]["index_crontab"]))
         except ValueError:

--- a/backend/src/config_test.py
+++ b/backend/src/config_test.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 from src.config import DEFAULT_CONFIG
-from src.config import Config as SingletonConfig
 from src.config import _Config as Config  # We don't want a singleton when we test.
 from src.config import initialize_config, write_default_config
 from src.errors import InvalidConfig
@@ -90,9 +89,3 @@ def test_update_default_config_add_section():
     parser = ConfigParser()
     parser.read(path)
     assert "repertoire" in parser
-
-
-def test_singleton():
-    c1 = SingletonConfig()
-    c2 = SingletonConfig()
-    assert c1 is c2

--- a/backend/src/conftest.py
+++ b/backend/src/conftest.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from yoyo import get_backend, read_migrations
 
 from src.config import Config, _Config
-from src.constants import TEST_DATA_PATH, Constants
+from src.constants import TEST_DATA_PATH, constants
 from src.fixtures.factory import Factory
 from src.util import database, freeze_database_time
 from src.webserver.app import create_app
@@ -33,9 +33,8 @@ def _create_seed_db():
     db_path = TEST_DATA_PATH / "db.sqlite3"
     db_path.unlink(missing_ok=True)
 
-    cons = Constants()
     db_backend = get_backend(f"sqlite:///{db_path}")
-    db_migrations = read_migrations(str(cons.migrations_path))
+    db_migrations = read_migrations(str(constants.migrations_path))
 
     freeze_database_time(db_backend._connection)
 
@@ -46,9 +45,8 @@ def _create_seed_db():
 @pytest.fixture(autouse=True)
 def isolated_dir():
     with CliRunner().isolated_filesystem():
-        cons = Constants()
-        cons.data_path = Path.cwd() / "_data"
-        cons.data_path.mkdir()
+        constants.data_path = Path.cwd() / "_data"
+        constants.data_path.mkdir()
         yield Path.cwd()
 
 
@@ -60,8 +58,7 @@ def stop_the_clock():
 
 @pytest.fixture
 def seed_data(seed_db, isolated_dir):
-    cons = Constants()
-    shutil.copytree(TEST_DATA_PATH, cons.data_path, dirs_exist_ok=True)
+    shutil.copytree(TEST_DATA_PATH, constants.data_path, dirs_exist_ok=True)
     # Update config cache with a new config.
     Config._config = _Config()
 

--- a/backend/src/conftest.py
+++ b/backend/src/conftest.py
@@ -7,7 +7,7 @@ from filelock import FileLock
 from freezegun import freeze_time
 from yoyo import get_backend, read_migrations
 
-from src.config import Config, _Config
+from src.config import _load_config, config
 from src.constants import TEST_DATA_PATH, constants
 from src.fixtures.factory import Factory
 from src.util import database, freeze_database_time
@@ -60,7 +60,7 @@ def stop_the_clock():
 def seed_data(seed_db, isolated_dir):
     shutil.copytree(TEST_DATA_PATH, constants.data_path, dirs_exist_ok=True)
     # Update config cache with a new config.
-    Config._config = _Config()
+    config.parser = _load_config(constants.config_path)
 
 
 @pytest.fixture
@@ -82,7 +82,6 @@ def quart_app(seed_data):
 @pytest.fixture
 async def quart_client(quart_app):
     def update_kwargs(token: bytes, **kwargs):
-        print(f"{token=}")
         kwargs["headers"] = {
             **kwargs.get("headers", {}),
             "Authorization": f"Token {token.hex()}",

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -54,7 +54,7 @@ class __Constants:
 
     def __init__(self):
         if IS_PYTEST:
-            self.data_path = Path.cwd() / "_data"
+            self.data_path = Path.cwd() / "test_data"
         elif IS_SPHINX:  # pragma: no cover
             self.data_path = TEST_DATA_PATH
         else:  # pragma: no cover

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -47,7 +47,7 @@ def _get_data_path() -> Path:
     return data_path
 
 
-class _Constants:
+class __Constants:
     """
     The "real" constants object that gets loaded as a singleton in ``Constants``.
     """
@@ -63,7 +63,7 @@ class _Constants:
         self._cover_art_mkdir = False
 
     @property
-    def cover_art_dir(self):
+    def cover_art_dir(self) -> Path:
         dir_ = self.data_path / "cover_art"
         if not self._cover_art_mkdir:
             logger.debug("Ensuring that cover art path exists.")
@@ -72,63 +72,31 @@ class _Constants:
         return dir_
 
     @property
-    def database_path(self):
+    def database_path(self) -> Path:
         return self.data_path / "db.sqlite3"
 
     @property
-    def huey_path(self):
+    def huey_path(self) -> Path:
         return self.data_path / "huey.sqlite3"
 
     @property
-    def config_path(self):
+    def config_path(self) -> Path:
         return self.data_path / "config.ini"
 
     @property
-    def pid_path(self):
+    def pid_path(self) -> Path:
         return self.data_path / "src.pid"
 
     @cached_property
-    def migrations_path(_):
+    def migrations_path(_) -> Path:
         return BACKEND_ROOT / "src" / "migrations" / "sql"
 
     @cached_property
-    def built_frontend_dir(_):
+    def built_frontend_dir(_) -> Path:
         try:
             return Path(os.getenv("BUILT_FRONTEND_DIR"))  # type: ignore
         except TypeError:
             return BACKEND_ROOT.parent / "frontend" / "build"
 
 
-class Constants:
-    """
-    A "proxy singleton" that returns the same constants instance when instantiated.
-
-    Other modules should only work with this singleton. This allows for code to fetch
-    the global constants object when needed.
-    """
-
-    _constants: _Constants
-
-    #: Data storage location.
-    data_path: Path
-    #: Storage location of cover art.
-    cover_art_dir: Path
-    #: Path to SQLite3 database.
-    database_path: Path
-    #: Path to Huey database.
-    huey_path: Path
-    #: Path to config ini file.
-    config_path: Path
-    #: Path to backend PID file.
-    pid_path: Path
-    #: Path to the database migrations.
-    migrations_path: Path
-    #: Path to the built Typescript frontend.
-    built_frontend_dir: Path
-
-    def __new__(cls) -> _Constants:  # type: ignore
-        try:
-            return cls._constants
-        except AttributeError:
-            cls._constants = _Constants()
-            return cls._constants
+constants = __Constants()

--- a/backend/src/enums.py
+++ b/backend/src/enums.py
@@ -41,11 +41,13 @@ class CollectionType(Enum):
     #:
     SYSTEM = 1
     #:
-    COLLAGE = 2
+    PERSONAL = 2
     #:
-    LABEL = 3
+    COLLAGE = 3
     #:
-    GENRE = 4
+    LABEL = 4
+    #:
+    GENRE = 5
 
 
 class PlaylistType(Enum):
@@ -54,7 +56,9 @@ class PlaylistType(Enum):
     #:
     SYSTEM = 1
     #:
-    PLAYLIST = 2
+    PERSONAL = 2
+    #:
+    PLAYLIST = 3
 
 
 class ReleaseSort(Enum):

--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -50,6 +50,10 @@ class InvalidPlaylistType(LibError):
     pass
 
 
+class InvalidArgument(LibError):
+    pass
+
+
 class Immutable(LibError):
     pass
 

--- a/backend/src/fixtures/factory.py
+++ b/backend/src/fixtures/factory.py
@@ -46,10 +46,12 @@ class Factory:
         conn: Connection,
         name: Optional[str] = None,
         type: Optional[CollectionType] = None,
+        user: Optional[libuser.T] = None,
     ) -> libcollection.T:
         return libcollection.create(
             name=name if name is not None else self.rand_string(12),
             type=type if type is not None else CollectionType.COLLAGE,
+            user_id=user.id if user else None,
             conn=conn,
             override_immutable=True,
         )
@@ -121,11 +123,13 @@ class Factory:
         *,
         conn: Connection,
         name: Optional[str] = None,
+        user: Optional[libuser.T] = None,
         type: Optional[PlaylistType] = None,
     ) -> libplaylist.T:
         return libplaylist.create(
             name=name if name is not None else self.rand_string(12),
             type=type if type is not None else PlaylistType.PLAYLIST,
+            user_id=user.id if user else None,
             conn=conn,
             override_immutable=True,
         )

--- a/backend/src/graphql/schema.gql
+++ b/backend/src/graphql/schema.gql
@@ -497,6 +497,9 @@ type TopGenre {
 type User {
   id: Int!
   nickname: String!
+  inboxCollectionId: Int!
+  favoritesCollectionId: Int!
+  favoritesPlaylistId: Int!
 }
 
 type Token {

--- a/backend/src/graphql/schema.gql
+++ b/backend/src/graphql/schema.gql
@@ -468,7 +468,7 @@ type Track {
   trackNumber: String!
   discNumber: String!
   "Whether the track is in the user's favorites playlist."
-  favorited: Boolean!
+  inFavorites: Boolean!
 
   release: Release!
   artists: [TrackArtist!]!

--- a/backend/src/graphql/schema.gql
+++ b/backend/src/graphql/schema.gql
@@ -47,10 +47,12 @@ type Query {
   "Fetch a collection by ID."
   collection(id: Int!): Collection!
 
-  "Fetch a collection by name and type."
-  collectionFromNameAndType(
+  "Fetch a collection by name, type, and user."
+  collectionFromNameTypeUser(
     name: String!
     type: CollectionType!
+    "The user the collection belongs to."
+    user: Int
   ): Collection!
 
   "Fetch invites."
@@ -93,10 +95,12 @@ type Query {
   "Fetch a playlist by ID."
   playlist(id: Int!): Playlist!
 
-  "Fetch a playlist by name and type."
-  playlistFromNameAndType(
+  "Fetch a playlist by name, type, and user."
+  playlistFromNameTypeUser(
     name: String!
     type: PlaylistType!
+    "The user the collection belongs to."
+    user: Int
   ): Playlist!
 
   "Search releases."
@@ -356,6 +360,9 @@ type Collection {
   releases: [Release!]!
   "The top genres of the collection, compiled from its releases."
   topGenres: [TopGenre!]!
+
+  "The user the collection belongs to."
+  user: User
 }
 
 type Collections {
@@ -395,6 +402,9 @@ type Playlist {
   entries: [PlaylistEntry!]!
   "The top genres of the playlist, compiled from its tracks."
   topGenres: [TopGenre!]!
+
+  "The user the playlist belongs to."
+  user: User
 }
 
 type Playlists {

--- a/backend/src/graphql/schema.gql
+++ b/backend/src/graphql/schema.gql
@@ -35,6 +35,8 @@ type Query {
     search: String
     "If provided, only collections of these type will be returned."
     types: [CollectionType!]
+    "If provided, only collections owned by these users will be returned."
+    userIds: [Int!]
     "Which page of collections to return."
     page: Int
     """
@@ -83,6 +85,8 @@ type Query {
     search: String
     "If provided, only playlists of these type will be returned."
     types: [PlaylistType!]
+    "If provided, only playlists owned by these users will be returned."
+    userIds: [Int!]
     "Which page of playlists to return."
     page: Int
     """

--- a/backend/src/graphql/schema.gql
+++ b/backend/src/graphql/schema.gql
@@ -536,6 +536,7 @@ enum ReleaseType {
 
 enum CollectionType {
   SYSTEM
+  PERSONAL
   COLLAGE
   LABEL
   GENRE
@@ -560,5 +561,6 @@ enum TrackSort {
 
 enum PlaylistType {
   SYSTEM
+  PERSONAL
   PLAYLIST
 }

--- a/backend/src/graphql/types/collection.py
+++ b/backend/src/graphql/types/collection.py
@@ -30,7 +30,7 @@ def resolve_collection_from_name_type_user(
     info: GraphQLResolveInfo,
     name: str,
     type: CollectionType,
-    user: int,
+    user: Optional[int] = None,
 ) -> collection.T:
     if col := collection.from_name_type_user(name, type, info.context.db, user_id=user):
         return col

--- a/backend/src/graphql/types/collection.py
+++ b/backend/src/graphql/types/collection.py
@@ -30,7 +30,7 @@ def resolve_collection_from_name_and_type(
     name: str,
     type: CollectionType,
 ) -> collection.T:
-    if col := collection.from_name_and_type(name, type, info.context.db):
+    if col := collection.from_name_type_user(name, type, info.context.db):
         return col
 
     raise NotFound(f'Collection "{name}" of type {type.name} not found.')

--- a/backend/src/graphql/types/collection.py
+++ b/backend/src/graphql/types/collection.py
@@ -9,6 +9,7 @@ from src.graphql.mutation import mutation
 from src.graphql.query import query
 from src.graphql.util import commit
 from src.library import collection, release
+from src.library import user as libuser
 from src.util import convert_keys_case, del_pagination_keys
 
 gql_collection = ObjectType("Collection")
@@ -23,17 +24,20 @@ def resolve_collection(obj: Any, info: GraphQLResolveInfo, id: int) -> collectio
     raise NotFound(f"Collection {id} not found.")
 
 
-@query.field("collectionFromNameAndType")
-def resolve_collection_from_name_and_type(
+@query.field("collectionFromNameTypeUser")
+def resolve_collection_from_name_type_user(
     obj: Any,
     info: GraphQLResolveInfo,
     name: str,
     type: CollectionType,
+    user: int,
 ) -> collection.T:
-    if col := collection.from_name_type_user(name, type, info.context.db):
+    if col := collection.from_name_type_user(name, type, info.context.db, user_id=user):
         return col
 
-    raise NotFound(f'Collection "{name}" of type {type.name} not found.')
+    raise NotFound(
+        f'Collection "{name}" of type {type.name} and user {user} not found.'
+    )
 
 
 @query.field("collections")
@@ -61,6 +65,14 @@ def resolve_image_id(obj: collection.T, info: GraphQLResolveInfo) -> Optional[in
         return img.id
 
     return None
+
+
+@gql_collection.field("user")
+def resolve_user(obj: collection.T, info: GraphQLResolveInfo) -> Optional[libuser.T]:
+    if obj.user_id is None:
+        return None
+
+    return libuser.from_id(obj.user_id, info.context.db)
 
 
 @mutation.field("createCollection")

--- a/backend/src/graphql/types/collection_test.py
+++ b/backend/src/graphql/types/collection_test.py
@@ -38,7 +38,7 @@ async def test_collection_not_found(graphql_query, snapshot):
 async def test_collection_from_name_type_user(graphql_query, snapshot):
     query = """
         query {
-            collectionFromNameAndType(name: "Genre1", type: GENRE) {
+            collectionFromNameTypeUser(name: "Genre1", type: GENRE) {
                 ...CollectionFields
             }
         }
@@ -52,7 +52,7 @@ async def test_collection_from_name_type_user(graphql_query, snapshot):
 async def test_collection_from_name_type_user_not_found(graphql_query, snapshot):
     query = """
         query {
-            collectionFromNameAndType(name: "AAFEFOPAIEFPAJF", type: COLLAGE) {
+            collectionFromNameTypeUser(name: "AAFEFOPAIEFPAJF", type: COLLAGE) {
                 ...CollectionFields
             }
         }
@@ -178,7 +178,7 @@ async def test_create_collection(db: Connection, graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
-async def test_create_collection_duplicate(db: Connection, graphql_query, snapshot):
+async def test_create_collection_duplicate(graphql_query, snapshot):
     query = """
         mutation {
             createCollection(name: "Collage1", type: COLLAGE, starred: true) {
@@ -204,7 +204,7 @@ async def test_update_collection(db: Connection, graphql_query, snapshot):
     assert success is True
     snapshot.assert_match(data)
 
-    col = collection.from_id(3, db)
+    col = collection.from_id(5, db)
     assert col is not None
     assert col.name == "NewCollection"
     assert col.starred is True
@@ -223,7 +223,7 @@ async def test_update_collection_duplicate(db: Connection, graphql_query, snapsh
     assert success is True
     snapshot.assert_match(data)
 
-    col = collection.from_id(3, db)
+    col = collection.from_id(5, db)
     assert col is not None
     assert col.name != "Collage3"
 
@@ -321,7 +321,7 @@ async def test_add_release_to_collection_bad_release(
             }
         }
     """
-    col = collection.from_id(2, db)
+    col = collection.from_id(3, db)
     assert col is not None
 
     releases_before = collection.releases(col, db)
@@ -353,7 +353,7 @@ async def test_add_release_to_collection_already_exists(
             }
         }
     """
-    col = collection.from_id(3, db)
+    col = collection.from_id(5, db)
     assert col is not None
 
     releases_before = collection.releases(col, db)
@@ -385,7 +385,7 @@ async def test_del_release_from_collection(db: Connection, graphql_query, snapsh
     assert success is True
     snapshot.assert_match(data)
 
-    col = collection.from_id(3, db)
+    col = collection.from_id(5, db)
     assert col is not None
     assert 2 not in [r.id for r in collection.releases(col, db)]
 
@@ -427,7 +427,7 @@ async def test_del_release_from_collection_bad_release(
             }
         }
     """
-    col = collection.from_id(2, db)
+    col = collection.from_id(3, db)
     assert col is not None
 
     releases_before = collection.releases(col, db)

--- a/backend/src/graphql/types/collection_test.py
+++ b/backend/src/graphql/types/collection_test.py
@@ -10,7 +10,7 @@ from src.library import collection
 async def test_collection(graphql_query, snapshot):
     query = """
         query {
-            collection(id: 3) {
+            collection(id: 5) {
                 ...CollectionFields
             }
         }
@@ -117,7 +117,7 @@ async def test_collections_pagination(graphql_query, snapshot):
 async def test_collection_image(graphql_query):
     query = """
         query {
-            collection(id: 3) {
+            collection(id: 5) {
                 imageId
             }
         }
@@ -195,7 +195,7 @@ async def test_create_collection_duplicate(db: Connection, graphql_query, snapsh
 async def test_update_collection(db: Connection, graphql_query, snapshot):
     query = """
         mutation {
-            updateCollection(id: 3, name: "NewCollection", starred: true) {
+            updateCollection(id: 5, name: "NewCollection", starred: true) {
                 ...CollectionFields
             }
         }
@@ -214,7 +214,7 @@ async def test_update_collection(db: Connection, graphql_query, snapshot):
 async def test_update_collection_duplicate(db: Connection, graphql_query, snapshot):
     query = """
         mutation {
-            updateCollection(id: 3, name: "Collage3") {
+            updateCollection(id: 5, name: "Collage3") {
                 ...CollectionFields
             }
         }
@@ -311,7 +311,7 @@ async def test_add_release_to_collection_bad_release(
 ):
     query = """
         mutation {
-            addReleaseToCollection(collectionId: 2, releaseId: 9999) {
+            addReleaseToCollection(collectionId: 3, releaseId: 9999) {
                 collection {
                     ...CollectionFields
                 }
@@ -343,7 +343,7 @@ async def test_add_release_to_collection_already_exists(
 ):
     query = """
         mutation {
-            addReleaseToCollection(collectionId: 3, releaseId: 2) {
+            addReleaseToCollection(collectionId: 5, releaseId: 2) {
                 collection {
                     ...CollectionFields
                 }
@@ -371,7 +371,7 @@ async def test_add_release_to_collection_already_exists(
 async def test_del_release_from_collection(db: Connection, graphql_query, snapshot):
     query = """
         mutation {
-            delReleaseFromCollection(collectionId: 3, releaseId: 2) {
+            delReleaseFromCollection(collectionId: 5, releaseId: 2) {
                 collection {
                     ...CollectionFields
                 }
@@ -417,7 +417,7 @@ async def test_del_release_from_collection_bad_release(
 ):
     query = """
         mutation {
-            delReleaseFromCollection(collectionId: 2, releaseId: 9999) {
+            delReleaseFromCollection(collectionId: 3, releaseId: 9999) {
                 collection {
                     ...CollectionFields
                 }

--- a/backend/src/graphql/types/collection_test.py
+++ b/backend/src/graphql/types/collection_test.py
@@ -114,6 +114,22 @@ async def test_collections_pagination(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
+async def test_collection_user(graphql_query):
+    query = """
+        query {
+            collection(id: 1) {
+                user {
+                    id
+                }
+            }
+        }
+    """
+    success, data = await graphql_query(query)
+    assert success is True
+    assert data["data"]["collection"]["user"]["id"] == 1
+
+
+@pytest.mark.asyncio
 async def test_collection_image(graphql_query):
     query = """
         query {

--- a/backend/src/graphql/types/collection_test.py
+++ b/backend/src/graphql/types/collection_test.py
@@ -35,7 +35,7 @@ async def test_collection_not_found(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
-async def test_collection_from_name_and_type(graphql_query, snapshot):
+async def test_collection_from_name_type_user(graphql_query, snapshot):
     query = """
         query {
             collectionFromNameAndType(name: "Genre1", type: GENRE) {
@@ -49,7 +49,7 @@ async def test_collection_from_name_and_type(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
-async def test_collection_from_name_and_type_not_found(graphql_query, snapshot):
+async def test_collection_from_name_type_user_not_found(graphql_query, snapshot):
     query = """
         query {
             collectionFromNameAndType(name: "AAFEFOPAIEFPAJF", type: COLLAGE) {

--- a/backend/src/graphql/types/conftest.py
+++ b/backend/src/graphql/types/conftest.py
@@ -58,7 +58,7 @@ def seed_gql_db(tmp_path_factory, worker_id, seed_db):
     """
     This fixture augments the existing migrated seed database with test data.
     """
-    if worker_id == "master":
+    if worker_id == "master":  # pragma: no cover
         _create_seed_gql_db()
 
     root_tmp_dir = tmp_path_factory.getbasetemp().parent

--- a/backend/src/graphql/types/conftest.py
+++ b/backend/src/graphql/types/conftest.py
@@ -16,7 +16,7 @@ import quart
 from ariadne import graphql
 from filelock import FileLock
 
-from src.constants import TEST_DATA_PATH, Constants
+from src.constants import TEST_DATA_PATH, constants
 from src.enums import ArtistRole, CollectionType, PlaylistType, ReleaseType
 from src.fixtures.factory import Factory
 from src.fixtures.fragments import FRAGMENTS
@@ -90,9 +90,8 @@ def seed_gql_data(seed_data, seed_gql_db):
     This fixture replaces the seeded database in the isolated test directory with the
     database containing test data.
     """
-    cons = Constants()
-    cons.database_path.unlink(missing_ok=True)
-    shutil.copyfile(GQL_DB_PATH, cons.database_path)
+    constants.database_path.unlink(missing_ok=True)
+    shutil.copyfile(GQL_DB_PATH, constants.database_path)
 
 
 def _add_test_data(conn: Connection):

--- a/backend/src/graphql/types/conftest.py
+++ b/backend/src/graphql/types/conftest.py
@@ -111,7 +111,7 @@ def _add_test_data(conn: Connection):
         factory.artist(name="Artist5", conn=conn),
     ]
 
-    # These start at ID 3.
+    # These start at ID 5.
 
     collages = [
         factory.collection(name="Collage1", type=CollectionType.COLLAGE, conn=conn),
@@ -147,7 +147,7 @@ def _add_test_data(conn: Connection):
         factory.invite(by_user=usr_admin, conn=conn, used_by=usr_blissful),
     ]
 
-    # These start at ID 2.
+    # These start at ID 3.
 
     playlists = [
         factory.playlist(name="Playlist1", type=PlaylistType.PLAYLIST, conn=conn),

--- a/backend/src/graphql/types/playlist.py
+++ b/backend/src/graphql/types/playlist.py
@@ -10,6 +10,7 @@ from src.graphql.query import query
 from src.graphql.util import commit
 from src.library import playlist
 from src.library import playlist_entry as pentry
+from src.library import user as libuser
 from src.util import convert_keys_case, del_pagination_keys
 
 gql_playlist = ObjectType("Playlist")
@@ -24,17 +25,18 @@ def resolve_playlist(obj: Any, info: GraphQLResolveInfo, id: int) -> playlist.T:
     raise NotFound(f"Playlist {id} not found.")
 
 
-@query.field("playlistFromNameAndType")
-def resolve_playlist_from_name_and_type(
+@query.field("playlistFromNameTypeUser")
+def resolve_playlist_from_name_type_user(
     obj: Any,
     info: GraphQLResolveInfo,
     name: str,
     type: PlaylistType,
+    user: int,
 ) -> playlist.T:
-    if ply := playlist.from_name_and_type(name, type, info.context.db):
+    if ply := playlist.from_name_type_user(name, type, info.context.db, user_id=user):
         return ply
 
-    raise NotFound(f'Playlist "{name}" of type {type.name} not found.')
+    raise NotFound(f'Playlist "{name}" of type {type.name} and user {user} not found.')
 
 
 @query.field("playlists")
@@ -62,6 +64,14 @@ def resolve_image_id(obj: playlist.T, info: GraphQLResolveInfo) -> Optional[int]
         return img.id
 
     return None
+
+
+@gql_playlist.field("user")
+def resolve_user(obj: playlist.T, info: GraphQLResolveInfo) -> Optional[libuser.T]:
+    if obj.user_id is None:
+        return None
+
+    return libuser.from_id(obj.user_id, info.context.db)
 
 
 @mutation.field("createPlaylist")

--- a/backend/src/graphql/types/playlist.py
+++ b/backend/src/graphql/types/playlist.py
@@ -31,7 +31,7 @@ def resolve_playlist_from_name_type_user(
     info: GraphQLResolveInfo,
     name: str,
     type: PlaylistType,
-    user: int,
+    user: Optional[int] = None,
 ) -> playlist.T:
     if ply := playlist.from_name_type_user(name, type, info.context.db, user_id=user):
         return ply

--- a/backend/src/graphql/types/playlist_entry_test.py
+++ b/backend/src/graphql/types/playlist_entry_test.py
@@ -117,7 +117,7 @@ async def test_delete_entry_invalid(graphql_query, snapshot):
 async def test_delete_entries(db: Connection, graphql_query, snapshot):
     query = """
         mutation {
-            delPlaylistEntries(playlistId: 2, trackId: 1) {
+            delPlaylistEntries(playlistId: 3, trackId: 1) {
                 playlist {
                     ...PlaylistFields
                 }
@@ -127,13 +127,13 @@ async def test_delete_entries(db: Connection, graphql_query, snapshot):
             }
         }
     """
-    assert pentry.from_playlist_and_track(2, 1, db) != []
+    assert pentry.from_playlist_and_track(3, 1, db) != []
 
     success, data = await graphql_query(query)
     assert success is True
     snapshot.assert_match(data)
 
-    assert pentry.from_playlist_and_track(2, 1, db) == []
+    assert pentry.from_playlist_and_track(3, 1, db) == []
 
 
 @pytest.mark.asyncio
@@ -153,7 +153,7 @@ async def test_update_playlist_entry(db: Connection, graphql_query, snapshot):
         """
         SELECT id
         FROM music__playlists_tracks
-        WHERE playlist_id = 2
+        WHERE playlist_id = 3
         ORDER BY position ASC
         """
     )

--- a/backend/src/graphql/types/playlist_entry_test.py
+++ b/backend/src/graphql/types/playlist_entry_test.py
@@ -10,7 +10,7 @@ from src.library import playlist_entry as pentry
 async def test_resolve_playlist_entries(graphql_query, snapshot):
     query = """
         query {
-            playlist(id: 2) {
+            playlist(id: 3) {
                 entries {
                     ...PlaylistEntryFields
                 }

--- a/backend/src/graphql/types/playlist_test.py
+++ b/backend/src/graphql/types/playlist_test.py
@@ -115,6 +115,22 @@ async def test_playlists_pagination(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
+async def test_playlist_user(graphql_query):
+    query = """
+        query {
+            playlist(id: 1) {
+                user {
+                    id
+                }
+            }
+        }
+    """
+    success, data = await graphql_query(query)
+    assert success is True
+    assert data["data"]["playlist"]["user"]["id"] == 1
+
+
+@pytest.mark.asyncio
 async def test_playlist_image(graphql_query):
     query = """
         query {

--- a/backend/src/graphql/types/playlist_test.py
+++ b/backend/src/graphql/types/playlist_test.py
@@ -35,10 +35,10 @@ async def test_playlist_not_found(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
-async def test_playlist_from_name_and_type(graphql_query, snapshot):
+async def test_playlist_from_name_type_user(graphql_query, snapshot):
     query = """
         query {
-            playlistFromNameAndType(name: "playlist1", type: PLAYLIST) {
+            playlistFromNameTypeUser(name: "playlist1", type: PLAYLIST) {
                 ...PlaylistFields
             }
         }
@@ -50,10 +50,10 @@ async def test_playlist_from_name_and_type(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
-async def test_playlist_from_name_and_type_not_found(graphql_query, snapshot):
+async def test_playlist_from_name_type_user_not_found(graphql_query, snapshot):
     query = """
         query {
-            playlistFromNameAndType(name: "AAFEFOPAIEFPAJF", type: SYSTEM) {
+            playlistFromNameTypeUser(name: "AAFEFOPAIEFPAJF", type: SYSTEM) {
                 ...PlaylistFields
             }
         }
@@ -204,7 +204,7 @@ async def test_update_playlist(db: Connection, graphql_query, snapshot):
     assert success is True
     snapshot.assert_match(data)
 
-    ply = playlist.from_id(3, db)
+    ply = playlist.from_id(4, db)
     assert ply is not None
     assert ply.name == "NewPlaylist"
     assert ply.starred is True
@@ -223,7 +223,7 @@ async def test_update_playlist_duplicate(db: Connection, graphql_query, snapshot
     assert success is True
     snapshot.assert_match(data)
 
-    ply = playlist.from_id(2, db)
+    ply = playlist.from_id(3, db)
     assert ply is not None
     assert ply.name != "Playlist3"
 

--- a/backend/src/graphql/types/playlist_test.py
+++ b/backend/src/graphql/types/playlist_test.py
@@ -10,7 +10,7 @@ from src.library import playlist
 async def test_playlist(graphql_query, snapshot):
     query = """
         query {
-            playlist(id: 2) {
+            playlist(id: 3) {
                 ...PlaylistFields
             }
         }
@@ -118,7 +118,7 @@ async def test_playlists_pagination(graphql_query, snapshot):
 async def test_playlist_image(graphql_query):
     query = """
         query {
-            playlist(id: 2) {
+            playlist(id: 3) {
                 imageId
             }
         }
@@ -195,7 +195,7 @@ async def test_create_playlist_duplicate(graphql_query, snapshot):
 async def test_update_playlist(db: Connection, graphql_query, snapshot):
     query = """
         mutation {
-            updatePlaylist(id: 3, name: "NewPlaylist", starred: true) {
+            updatePlaylist(id: 4, name: "NewPlaylist", starred: true) {
                 ...PlaylistFields
             }
         }
@@ -214,7 +214,7 @@ async def test_update_playlist(db: Connection, graphql_query, snapshot):
 async def test_update_playlist_duplicate(db: Connection, graphql_query, snapshot):
     query = """
         mutation {
-            updatePlaylist(id: 2, name: "Playlist3") {
+            updatePlaylist(id: 3, name: "Playlist3") {
                 ...PlaylistFields
             }
         }

--- a/backend/src/graphql/types/release.py
+++ b/backend/src/graphql/types/release.py
@@ -34,6 +34,16 @@ def resolve_releases(_: Any, info: GraphQLResolveInfo, **kwargs) -> dict:
     }
 
 
+@gql_release.field("inInbox")
+def resolve_in_inbox(obj: release.T, info: GraphQLResolveInfo) -> bool:
+    return release.in_inbox(obj, info.context.user.id, info.context.db)
+
+
+@gql_release.field("inFavorites")
+def resolve_in_favorites(obj: release.T, info: GraphQLResolveInfo) -> bool:
+    return release.in_favorites(obj, info.context.user.id, info.context.db)
+
+
 @gql_release.field("artists")
 def resolve_artists(obj: release.T, info: GraphQLResolveInfo) -> list[artist.T]:
     return release.artists(obj, info.context.db)

--- a/backend/src/graphql/types/release_test.py
+++ b/backend/src/graphql/types/release_test.py
@@ -72,7 +72,7 @@ async def test_releases_search(graphql_query, snapshot):
 async def test_releases_filter_collections(graphql_query, snapshot):
     query = """
         query {
-            releases(collectionIds: [3]) {
+            releases(collectionIds: [5]) {
                 total
                 results {
                     ...ReleaseFields

--- a/backend/src/graphql/types/snapshots/snap_artist_test.py
+++ b/backend/src/graphql/types/snapshots/snap_artist_test.py
@@ -27,19 +27,19 @@ snapshots['test_artist 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
-                    },
-                    'numMatches': 1
-                },
-                {
-                    'genre': {
-                        'id': 10
-                    },
-                    'numMatches': 1
-                },
-                {
-                    'genre': {
                         'id': 11
+                    },
+                    'numMatches': 1
+                },
+                {
+                    'genre': {
+                        'id': 12
+                    },
+                    'numMatches': 1
+                },
+                {
+                    'genre': {
+                        'id': 13
                     },
                     'numMatches': 1
                 }
@@ -68,19 +68,19 @@ snapshots['test_artist_from_name 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
-                    },
-                    'numMatches': 1
-                },
-                {
-                    'genre': {
-                        'id': 10
-                    },
-                    'numMatches': 1
-                },
-                {
-                    'genre': {
                         'id': 11
+                    },
+                    'numMatches': 1
+                },
+                {
+                    'genre': {
+                        'id': 12
+                    },
+                    'numMatches': 1
+                },
+                {
+                    'genre': {
+                        'id': 13
                     },
                     'numMatches': 1
                 }
@@ -149,19 +149,19 @@ snapshots['test_artists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
                                 'id': 11
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 13
                             },
                             'numMatches': 1
                         }
@@ -185,13 +185,13 @@ snapshots['test_artists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 2
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 2
                         }
@@ -215,19 +215,19 @@ snapshots['test_artists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
                                 'id': 11
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 13
                             },
                             'numMatches': 1
                         }
@@ -247,13 +247,13 @@ snapshots['test_artists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 1
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 1
                         }
@@ -273,7 +273,7 @@ snapshots['test_artists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 11
+                                'id': 13
                             },
                             'numMatches': 1
                         }
@@ -321,13 +321,13 @@ snapshots['test_artists_pagination 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 2
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 2
                         }
@@ -361,19 +361,19 @@ snapshots['test_artists_search 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
                                 'id': 11
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 13
                             },
                             'numMatches': 1
                         }
@@ -439,19 +439,19 @@ snapshots['test_update_artist 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
-                    },
-                    'numMatches': 1
-                },
-                {
-                    'genre': {
-                        'id': 10
-                    },
-                    'numMatches': 1
-                },
-                {
-                    'genre': {
                         'id': 11
+                    },
+                    'numMatches': 1
+                },
+                {
+                    'genre': {
+                        'id': 12
+                    },
+                    'numMatches': 1
+                },
+                {
+                    'genre': {
+                        'id': 13
                     },
                     'numMatches': 1
                 }

--- a/backend/src/graphql/types/snapshots/snap_collection_test.py
+++ b/backend/src/graphql/types/snapshots/snap_collection_test.py
@@ -25,13 +25,13 @@ snapshots['test_add_release_to_collection 1'] = {
                 'topGenres': [
                     {
                         'genre': {
-                            'id': 9
+                            'id': 11
                         },
                         'numMatches': 1
                     },
                     {
                         'genre': {
-                            'id': 10
+                            'id': 12
                         },
                         'numMatches': 1
                     }
@@ -52,21 +52,21 @@ snapshots['test_add_release_to_collection 1'] = {
                 ],
                 'collages': [
                     {
-                        'id': 3,
+                        'id': 5,
                         'name': 'Collage1'
                     },
                     {
-                        'id': 4,
+                        'id': 6,
                         'name': 'Collage2'
                     }
                 ],
                 'genres': [
                     {
-                        'id': 9,
+                        'id': 11,
                         'name': 'Genre1'
                     },
                     {
-                        'id': 10,
+                        'id': 12,
                         'name': 'Genre2'
                     }
                 ],
@@ -76,7 +76,7 @@ snapshots['test_add_release_to_collection 1'] = {
                 'inInbox': True,
                 'labels': [
                     {
-                        'id': 6,
+                        'id': 8,
                         'name': 'Label1'
                     }
                 ],
@@ -165,7 +165,7 @@ snapshots['test_add_release_to_collection_bad_release 1'] = {
 snapshots['test_collection 1'] = {
     'data': {
         'collection': {
-            'id': 3,
+            'id': 5,
             'lastUpdatedOn': 1577840461,
             'name': 'Collage1',
             'numReleases': 3,
@@ -187,13 +187,13 @@ snapshots['test_collection 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
+                        'id': 11
                     },
                     'numMatches': 3
                 },
                 {
                     'genre': {
-                        'id': 10
+                        'id': 12
                     },
                     'numMatches': 3
                 }
@@ -203,10 +203,10 @@ snapshots['test_collection 1'] = {
     }
 }
 
-snapshots['test_collection_from_name_and_type 1'] = {
+snapshots['test_collection_from_name_type_user 1'] = {
     'data': {
-        'collectionFromNameAndType': {
-            'id': 9,
+        'collectionFromNameTypeUser': {
+            'id': 11,
             'lastUpdatedOn': 1577840461,
             'name': 'Genre1',
             'numReleases': 3,
@@ -228,13 +228,13 @@ snapshots['test_collection_from_name_and_type 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
+                        'id': 11
                     },
                     'numMatches': 3
                 },
                 {
                     'genre': {
-                        'id': 10
+                        'id': 12
                     },
                     'numMatches': 3
                 }
@@ -244,7 +244,7 @@ snapshots['test_collection_from_name_and_type 1'] = {
     }
 }
 
-snapshots['test_collection_from_name_and_type_not_found 1'] = {
+snapshots['test_collection_from_name_type_user_not_found 1'] = {
     'data': None,
     'errors': [
         {
@@ -254,51 +254,9 @@ snapshots['test_collection_from_name_and_type_not_found 1'] = {
                     'line': 3
                 }
             ],
-            'message': 'Collection "AAFEFOPAIEFPAJF" of type COLLAGE not found.',
+            'message': 'Collection "AAFEFOPAIEFPAJF" of type COLLAGE and user None not found.',
             'path': [
-                'collectionFromNameAndType'
-            ],
-            'type': 'NotFound'
-        }
-    ]
-}
-
-snapshots['test_collection_from_name_type_user 1'] = {
-    'data': {
-        'collectionFromNameAndType': None
-    },
-    'errors': [
-        {
-            'locations': [
-                {
-                    'column': 13,
-                    'line': 3
-                }
-            ],
-            'message': 'Collection "Genre1" of type GENRE not found.',
-            'path': [
-                'collectionFromNameAndType'
-            ],
-            'type': 'NotFound'
-        }
-    ]
-}
-
-snapshots['test_collection_from_name_type_user_not_found 1'] = {
-    'data': {
-        'collectionFromNameAndType': None
-    },
-    'errors': [
-        {
-            'locations': [
-                {
-                    'column': 13,
-                    'line': 3
-                }
-            ],
-            'message': 'Collection "AAFEFOPAIEFPAJF" of type COLLAGE not found.',
-            'path': [
-                'collectionFromNameAndType'
+                'collectionFromNameTypeUser'
             ],
             'type': 'NotFound'
         }
@@ -341,385 +299,7 @@ snapshots['test_collections 1'] = {
                     'type': 'SYSTEM'
                 },
                 {
-                    'id': 1,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Inbox',
-                    'numReleases': 0,
-                    'releases': [
-                    ],
-                    'starred': True,
-                    'topGenres': [
-                    ],
-                    'type': 'SYSTEM'
-                },
-                {
-                    'id': 3,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Collage1',
-                    'numReleases': 3,
-                    'releases': [
-                        {
-                            'id': 2,
-                            'title': 'Release1'
-                        },
-                        {
-                            'id': 3,
-                            'title': 'Release2'
-                        },
-                        {
-                            'id': 4,
-                            'title': 'Release3'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 3
-                        }
-                    ],
-                    'type': 'COLLAGE'
-                },
-                {
                     'id': 4,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Collage2',
-                    'numReleases': 1,
-                    'releases': [
-                        {
-                            'id': 2,
-                            'title': 'Release1'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 1
-                        }
-                    ],
-                    'type': 'COLLAGE'
-                },
-                {
-                    'id': 5,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Collage3',
-                    'numReleases': 0,
-                    'releases': [
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                    ],
-                    'type': 'COLLAGE'
-                },
-                {
-                    'id': 6,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Label1',
-                    'numReleases': 2,
-                    'releases': [
-                        {
-                            'id': 2,
-                            'title': 'Release1'
-                        },
-                        {
-                            'id': 3,
-                            'title': 'Release2'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 2
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 2
-                        }
-                    ],
-                    'type': 'LABEL'
-                },
-                {
-                    'id': 7,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Label2',
-                    'numReleases': 2,
-                    'releases': [
-                        {
-                            'id': 4,
-                            'title': 'Release3'
-                        },
-                        {
-                            'id': 5,
-                            'title': 'Release4'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
-                                'id': 11
-                            },
-                            'numMatches': 1
-                        }
-                    ],
-                    'type': 'LABEL'
-                },
-                {
-                    'id': 8,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Label3',
-                    'numReleases': 0,
-                    'releases': [
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                    ],
-                    'type': 'LABEL'
-                },
-                {
-                    'id': 9,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Genre1',
-                    'numReleases': 3,
-                    'releases': [
-                        {
-                            'id': 2,
-                            'title': 'Release1'
-                        },
-                        {
-                            'id': 3,
-                            'title': 'Release2'
-                        },
-                        {
-                            'id': 4,
-                            'title': 'Release3'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 3
-                        }
-                    ],
-                    'type': 'GENRE'
-                },
-                {
-                    'id': 10,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Genre2',
-                    'numReleases': 3,
-                    'releases': [
-                        {
-                            'id': 2,
-                            'title': 'Release1'
-                        },
-                        {
-                            'id': 3,
-                            'title': 'Release2'
-                        },
-                        {
-                            'id': 4,
-                            'title': 'Release3'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 3
-                        }
-                    ],
-                    'type': 'GENRE'
-                },
-                {
-                    'id': 11,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Genre3',
-                    'numReleases': 2,
-                    'releases': [
-                        {
-                            'id': 5,
-                            'title': 'Release4'
-                        },
-                        {
-                            'id': 6,
-                            'title': 'Release5'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 11
-                            },
-                            'numMatches': 2
-                        }
-                    ],
-                    'type': 'GENRE'
-                }
-            ],
-            'total': 11
-        }
-    }
-}
-
-snapshots['test_collections_filter 1'] = {
-    'data': {
-        'collections': {
-            'results': [
-                {
-                    'id': 9,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Genre1',
-                    'numReleases': 3,
-                    'releases': [
-                        {
-                            'id': 2,
-                            'title': 'Release1'
-                        },
-                        {
-                            'id': 3,
-                            'title': 'Release2'
-                        },
-                        {
-                            'id': 4,
-                            'title': 'Release3'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 3
-                        }
-                    ],
-                    'type': 'GENRE'
-                }
-            ],
-            'total': 1
-        }
-    }
-}
-
-snapshots['test_collections_pagination 1'] = {
-    'data': {
-        'collections': {
-            'results': [
-                {
-                    'id': 5,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Collage3',
-                    'numReleases': 0,
-                    'releases': [
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                    ],
-                    'type': 'COLLAGE'
-                },
-                {
-                    'id': 6,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Label1',
-                    'numReleases': 2,
-                    'releases': [
-                        {
-                            'id': 2,
-                            'title': 'Release1'
-                        },
-                        {
-                            'id': 3,
-                            'title': 'Release2'
-                        }
-                    ],
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 2
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 2
-                        }
-                    ],
-                    'type': 'LABEL'
-                }
-            ],
-            'total': 11
-        }
-    }
-}
-
-snapshots['test_collections_type_param 1'] = {
-    'data': {
-        'collections': {
-            'results': [
-                {
-                    'id': 2,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Favorites',
                     'numReleases': 0,
@@ -743,7 +323,177 @@ snapshots['test_collections_type_param 1'] = {
                     'type': 'SYSTEM'
                 },
                 {
+                    'id': 3,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Inbox',
+                    'numReleases': 0,
+                    'releases': [
+                    ],
+                    'starred': True,
+                    'topGenres': [
+                    ],
+                    'type': 'SYSTEM'
+                },
+                {
+                    'id': 5,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Collage1',
+                    'numReleases': 3,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        },
+                        {
+                            'id': 3,
+                            'title': 'Release2'
+                        },
+                        {
+                            'id': 4,
+                            'title': 'Release3'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 3
+                        }
+                    ],
+                    'type': 'COLLAGE'
+                },
+                {
+                    'id': 6,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Collage2',
+                    'numReleases': 1,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 1
+                        }
+                    ],
+                    'type': 'COLLAGE'
+                },
+                {
+                    'id': 7,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Collage3',
+                    'numReleases': 0,
+                    'releases': [
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                    ],
+                    'type': 'COLLAGE'
+                },
+                {
+                    'id': 8,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Label1',
+                    'numReleases': 2,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        },
+                        {
+                            'id': 3,
+                            'title': 'Release2'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 2
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 2
+                        }
+                    ],
+                    'type': 'LABEL'
+                },
+                {
                     'id': 9,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Label2',
+                    'numReleases': 2,
+                    'releases': [
+                        {
+                            'id': 4,
+                            'title': 'Release3'
+                        },
+                        {
+                            'id': 5,
+                            'title': 'Release4'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 13
+                            },
+                            'numMatches': 1
+                        }
+                    ],
+                    'type': 'LABEL'
+                },
+                {
+                    'id': 10,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Label3',
+                    'numReleases': 0,
+                    'releases': [
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                    ],
+                    'type': 'LABEL'
+                },
+                {
+                    'id': 11,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Genre1',
                     'numReleases': 3,
@@ -765,13 +515,13 @@ snapshots['test_collections_type_param 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 3
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 3
                         }
@@ -779,7 +529,7 @@ snapshots['test_collections_type_param 1'] = {
                     'type': 'GENRE'
                 },
                 {
-                    'id': 10,
+                    'id': 12,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Genre2',
                     'numReleases': 3,
@@ -801,13 +551,13 @@ snapshots['test_collections_type_param 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 3
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 3
                         }
@@ -815,7 +565,7 @@ snapshots['test_collections_type_param 1'] = {
                     'type': 'GENRE'
                 },
                 {
-                    'id': 11,
+                    'id': 13,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Genre3',
                     'numReleases': 2,
@@ -833,7 +583,283 @@ snapshots['test_collections_type_param 1'] = {
                     'topGenres': [
                         {
                             'genre': {
+                                'id': 13
+                            },
+                            'numMatches': 2
+                        }
+                    ],
+                    'type': 'GENRE'
+                }
+            ],
+            'total': 13
+        }
+    }
+}
+
+snapshots['test_collections_filter 1'] = {
+    'data': {
+        'collections': {
+            'results': [
+                {
+                    'id': 11,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Genre1',
+                    'numReleases': 3,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        },
+                        {
+                            'id': 3,
+                            'title': 'Release2'
+                        },
+                        {
+                            'id': 4,
+                            'title': 'Release3'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
                                 'id': 11
+                            },
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 3
+                        }
+                    ],
+                    'type': 'GENRE'
+                }
+            ],
+            'total': 1
+        }
+    }
+}
+
+snapshots['test_collections_pagination 1'] = {
+    'data': {
+        'collections': {
+            'results': [
+                {
+                    'id': 5,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Collage1',
+                    'numReleases': 3,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        },
+                        {
+                            'id': 3,
+                            'title': 'Release2'
+                        },
+                        {
+                            'id': 4,
+                            'title': 'Release3'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 3
+                        }
+                    ],
+                    'type': 'COLLAGE'
+                },
+                {
+                    'id': 6,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Collage2',
+                    'numReleases': 1,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 1
+                        }
+                    ],
+                    'type': 'COLLAGE'
+                }
+            ],
+            'total': 13
+        }
+    }
+}
+
+snapshots['test_collections_type_param 1'] = {
+    'data': {
+        'collections': {
+            'results': [
+                {
+                    'id': 2,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Favorites',
+                    'numReleases': 0,
+                    'releases': [
+                    ],
+                    'starred': True,
+                    'topGenres': [
+                    ],
+                    'type': 'SYSTEM'
+                },
+                {
+                    'id': 4,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Favorites',
+                    'numReleases': 0,
+                    'releases': [
+                    ],
+                    'starred': True,
+                    'topGenres': [
+                    ],
+                    'type': 'SYSTEM'
+                },
+                {
+                    'id': 1,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Inbox',
+                    'numReleases': 0,
+                    'releases': [
+                    ],
+                    'starred': True,
+                    'topGenres': [
+                    ],
+                    'type': 'SYSTEM'
+                },
+                {
+                    'id': 3,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Inbox',
+                    'numReleases': 0,
+                    'releases': [
+                    ],
+                    'starred': True,
+                    'topGenres': [
+                    ],
+                    'type': 'SYSTEM'
+                },
+                {
+                    'id': 11,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Genre1',
+                    'numReleases': 3,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        },
+                        {
+                            'id': 3,
+                            'title': 'Release2'
+                        },
+                        {
+                            'id': 4,
+                            'title': 'Release3'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 3
+                        }
+                    ],
+                    'type': 'GENRE'
+                },
+                {
+                    'id': 12,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Genre2',
+                    'numReleases': 3,
+                    'releases': [
+                        {
+                            'id': 2,
+                            'title': 'Release1'
+                        },
+                        {
+                            'id': 3,
+                            'title': 'Release2'
+                        },
+                        {
+                            'id': 4,
+                            'title': 'Release3'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 3
+                        }
+                    ],
+                    'type': 'GENRE'
+                },
+                {
+                    'id': 13,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Genre3',
+                    'numReleases': 2,
+                    'releases': [
+                        {
+                            'id': 5,
+                            'title': 'Release4'
+                        },
+                        {
+                            'id': 6,
+                            'title': 'Release5'
+                        }
+                    ],
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 13
                             },
                             'numMatches': 2
                         }
@@ -848,7 +874,7 @@ snapshots['test_collections_type_param 1'] = {
 snapshots['test_create_collection 1'] = {
     'data': {
         'createCollection': {
-            'id': 12,
+            'id': 14,
             'lastUpdatedOn': 1577840461,
             'name': 'NewCollection',
             'numReleases': 0,
@@ -885,7 +911,7 @@ snapshots['test_del_release_from_collection 1'] = {
     'data': {
         'delReleaseFromCollection': {
             'collection': {
-                'id': 3,
+                'id': 5,
                 'lastUpdatedOn': 1577840461,
                 'name': 'Collage1',
                 'numReleases': 2,
@@ -903,13 +929,13 @@ snapshots['test_del_release_from_collection 1'] = {
                 'topGenres': [
                     {
                         'genre': {
-                            'id': 9
+                            'id': 11
                         },
                         'numMatches': 2
                     },
                     {
                         'genre': {
-                            'id': 10
+                            'id': 12
                         },
                         'numMatches': 2
                     }
@@ -930,17 +956,17 @@ snapshots['test_del_release_from_collection 1'] = {
                 ],
                 'collages': [
                     {
-                        'id': 4,
+                        'id': 6,
                         'name': 'Collage2'
                     }
                 ],
                 'genres': [
                     {
-                        'id': 9,
+                        'id': 11,
                         'name': 'Genre1'
                     },
                     {
-                        'id': 10,
+                        'id': 12,
                         'name': 'Genre2'
                     }
                 ],
@@ -950,7 +976,7 @@ snapshots['test_del_release_from_collection 1'] = {
                 'inInbox': False,
                 'labels': [
                     {
-                        'id': 6,
+                        'id': 8,
                         'name': 'Label1'
                     }
                 ],
@@ -1039,7 +1065,7 @@ snapshots['test_del_release_from_collection_doesnt_exist 1'] = {
 snapshots['test_update_collection 1'] = {
     'data': {
         'updateCollection': {
-            'id': 3,
+            'id': 5,
             'lastUpdatedOn': 1577840461,
             'name': 'NewCollection',
             'numReleases': 3,
@@ -1061,13 +1087,13 @@ snapshots['test_update_collection 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
+                        'id': 11
                     },
                     'numMatches': 3
                 },
                 {
                     'genre': {
-                        'id': 10
+                        'id': 12
                     },
                     'numMatches': 3
                 }

--- a/backend/src/graphql/types/snapshots/snap_collection_test.py
+++ b/backend/src/graphql/types/snapshots/snap_collection_test.py
@@ -263,6 +263,48 @@ snapshots['test_collection_from_name_and_type_not_found 1'] = {
     ]
 }
 
+snapshots['test_collection_from_name_type_user 1'] = {
+    'data': {
+        'collectionFromNameAndType': None
+    },
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 13,
+                    'line': 3
+                }
+            ],
+            'message': 'Collection "Genre1" of type GENRE not found.',
+            'path': [
+                'collectionFromNameAndType'
+            ],
+            'type': 'NotFound'
+        }
+    ]
+}
+
+snapshots['test_collection_from_name_type_user_not_found 1'] = {
+    'data': {
+        'collectionFromNameAndType': None
+    },
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 13,
+                    'line': 3
+                }
+            ],
+            'message': 'Collection "AAFEFOPAIEFPAJF" of type COLLAGE not found.',
+            'path': [
+                'collectionFromNameAndType'
+            ],
+            'type': 'NotFound'
+        }
+    ]
+}
+
 snapshots['test_collection_not_found 1'] = {
     'data': None,
     'errors': [

--- a/backend/src/graphql/types/snapshots/snap_playlist_entry_test.py
+++ b/backend/src/graphql/types/snapshots/snap_playlist_entry_test.py
@@ -96,7 +96,7 @@ snapshots['test_delete_entries 1'] = {
                         }
                     }
                 ],
-                'id': 2,
+                'id': 3,
                 'lastUpdatedOn': 1577840461,
                 'name': 'Playlist1',
                 'numTracks': 4,
@@ -104,13 +104,13 @@ snapshots['test_delete_entries 1'] = {
                 'topGenres': [
                     {
                         'genre': {
-                            'id': 9
+                            'id': 11
                         },
                         'numMatches': 4
                     },
                     {
                         'genre': {
-                            'id': 10
+                            'id': 12
                         },
                         'numMatches': 4
                     }
@@ -182,7 +182,7 @@ snapshots['test_delete_entry 1'] = {
                         }
                     }
                 ],
-                'id': 2,
+                'id': 3,
                 'lastUpdatedOn': 1577840461,
                 'name': 'Playlist1',
                 'numTracks': 4,
@@ -190,13 +190,13 @@ snapshots['test_delete_entry 1'] = {
                 'topGenres': [
                     {
                         'genre': {
-                            'id': 9
+                            'id': 11
                         },
                         'numMatches': 4
                     },
                     {
                         'genre': {
-                            'id': 10
+                            'id': 12
                         },
                         'numMatches': 4
                     }
@@ -260,7 +260,7 @@ snapshots['test_resolve_playlist_entries 1'] = {
                 {
                     'id': 1,
                     'playlist': {
-                        'id': 2,
+                        'id': 3,
                         'name': 'Playlist1'
                     },
                     'position': 1,
@@ -272,7 +272,7 @@ snapshots['test_resolve_playlist_entries 1'] = {
                 {
                     'id': 2,
                     'playlist': {
-                        'id': 2,
+                        'id': 3,
                         'name': 'Playlist1'
                     },
                     'position': 2,
@@ -284,7 +284,7 @@ snapshots['test_resolve_playlist_entries 1'] = {
                 {
                     'id': 3,
                     'playlist': {
-                        'id': 2,
+                        'id': 3,
                         'name': 'Playlist1'
                     },
                     'position': 3,
@@ -296,7 +296,7 @@ snapshots['test_resolve_playlist_entries 1'] = {
                 {
                     'id': 4,
                     'playlist': {
-                        'id': 2,
+                        'id': 3,
                         'name': 'Playlist1'
                     },
                     'position': 4,
@@ -308,7 +308,7 @@ snapshots['test_resolve_playlist_entries 1'] = {
                 {
                     'id': 5,
                     'playlist': {
-                        'id': 2,
+                        'id': 3,
                         'name': 'Playlist1'
                     },
                     'position': 5,
@@ -327,7 +327,7 @@ snapshots['test_update_playlist_entry 1'] = {
         'updatePlaylistEntry': {
             'id': 3,
             'playlist': {
-                'id': 2,
+                'id': 3,
                 'name': 'Playlist1'
             },
             'position': 1,

--- a/backend/src/graphql/types/snapshots/snap_playlist_test.py
+++ b/backend/src/graphql/types/snapshots/snap_playlist_test.py
@@ -12,7 +12,7 @@ snapshots['test_create_playlist 1'] = {
         'createPlaylist': {
             'entries': [
             ],
-            'id': 5,
+            'id': 6,
             'lastUpdatedOn': 1577840461,
             'name': 'NewPlaylist',
             'numTracks': 0,
@@ -83,7 +83,7 @@ snapshots['test_playlist 1'] = {
                     }
                 }
             ],
-            'id': 2,
+            'id': 3,
             'lastUpdatedOn': 1577840461,
             'name': 'Playlist1',
             'numTracks': 5,
@@ -91,13 +91,13 @@ snapshots['test_playlist 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
+                        'id': 11
                     },
                     'numMatches': 5
                 },
                 {
                     'genre': {
-                        'id': 10
+                        'id': 12
                     },
                     'numMatches': 5
                 }
@@ -107,9 +107,9 @@ snapshots['test_playlist 1'] = {
     }
 }
 
-snapshots['test_playlist_from_name_and_type 1'] = {
+snapshots['test_playlist_from_name_type_user 1'] = {
     'data': {
-        'playlistFromNameAndType': {
+        'playlistFromNameTypeUser': {
             'entries': [
                 {
                     'id': 1,
@@ -147,7 +147,7 @@ snapshots['test_playlist_from_name_and_type 1'] = {
                     }
                 }
             ],
-            'id': 2,
+            'id': 3,
             'lastUpdatedOn': 1577840461,
             'name': 'Playlist1',
             'numTracks': 5,
@@ -155,13 +155,13 @@ snapshots['test_playlist_from_name_and_type 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
+                        'id': 11
                     },
                     'numMatches': 5
                 },
                 {
                     'genre': {
-                        'id': 10
+                        'id': 12
                     },
                     'numMatches': 5
                 }
@@ -171,7 +171,7 @@ snapshots['test_playlist_from_name_and_type 1'] = {
     }
 }
 
-snapshots['test_playlist_from_name_and_type_not_found 1'] = {
+snapshots['test_playlist_from_name_type_user_not_found 1'] = {
     'data': None,
     'errors': [
         {
@@ -181,9 +181,9 @@ snapshots['test_playlist_from_name_and_type_not_found 1'] = {
                     'line': 3
                 }
             ],
-            'message': 'Playlist "AAFEFOPAIEFPAJF" of type SYSTEM not found.',
+            'message': 'Playlist "AAFEFOPAIEFPAJF" of type SYSTEM and user None not found.',
             'path': [
-                'playlistFromNameAndType'
+                'playlistFromNameTypeUser'
             ],
             'type': 'NotFound'
         }
@@ -217,6 +217,18 @@ snapshots['test_playlists 1'] = {
                     'entries': [
                     ],
                     'id': 1,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Favorites',
+                    'numTracks': 0,
+                    'starred': True,
+                    'topGenres': [
+                    ],
+                    'type': 'SYSTEM'
+                },
+                {
+                    'entries': [
+                    ],
+                    'id': 2,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Favorites',
                     'numTracks': 0,
@@ -263,7 +275,7 @@ snapshots['test_playlists 1'] = {
                             }
                         }
                     ],
-                    'id': 2,
+                    'id': 3,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Playlist1',
                     'numTracks': 5,
@@ -271,13 +283,13 @@ snapshots['test_playlists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 5
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 5
                         }
@@ -308,7 +320,7 @@ snapshots['test_playlists 1'] = {
                             }
                         }
                     ],
-                    'id': 3,
+                    'id': 4,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Playlist2',
                     'numTracks': 3,
@@ -316,13 +328,13 @@ snapshots['test_playlists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 3
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 3
                         }
@@ -367,7 +379,7 @@ snapshots['test_playlists 1'] = {
                             }
                         }
                     ],
-                    'id': 4,
+                    'id': 5,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Playlist3',
                     'numTracks': 5,
@@ -375,19 +387,19 @@ snapshots['test_playlists 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
                                 'id': 11
+                            },
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 13
                             },
                             'numMatches': 2
                         }
@@ -395,7 +407,7 @@ snapshots['test_playlists 1'] = {
                     'type': 'PLAYLIST'
                 }
             ],
-            'total': 4
+            'total': 5
         }
     }
 }
@@ -442,7 +454,7 @@ snapshots['test_playlists_filter 1'] = {
                             }
                         }
                     ],
-                    'id': 2,
+                    'id': 3,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Playlist1',
                     'numTracks': 5,
@@ -450,13 +462,13 @@ snapshots['test_playlists_filter 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 5
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 5
                         }
@@ -473,6 +485,65 @@ snapshots['test_playlists_pagination 1'] = {
     'data': {
         'playlists': {
             'results': [
+                {
+                    'entries': [
+                        {
+                            'id': 1,
+                            'track': {
+                                'id': 1,
+                                'title': 'Track0'
+                            }
+                        },
+                        {
+                            'id': 2,
+                            'track': {
+                                'id': 2,
+                                'title': 'Track1'
+                            }
+                        },
+                        {
+                            'id': 3,
+                            'track': {
+                                'id': 3,
+                                'title': 'Track2'
+                            }
+                        },
+                        {
+                            'id': 4,
+                            'track': {
+                                'id': 4,
+                                'title': 'Track3'
+                            }
+                        },
+                        {
+                            'id': 5,
+                            'track': {
+                                'id': 5,
+                                'title': 'Track4'
+                            }
+                        }
+                    ],
+                    'id': 3,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Playlist1',
+                    'numTracks': 5,
+                    'starred': False,
+                    'topGenres': [
+                        {
+                            'genre': {
+                                'id': 11
+                            },
+                            'numMatches': 5
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 5
+                        }
+                    ],
+                    'type': 'PLAYLIST'
+                },
                 {
                     'entries': [
                         {
@@ -497,7 +568,7 @@ snapshots['test_playlists_pagination 1'] = {
                             }
                         }
                     ],
-                    'id': 3,
+                    'id': 4,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Playlist2',
                     'numTracks': 3,
@@ -505,86 +576,21 @@ snapshots['test_playlists_pagination 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 3
-                        }
-                    ],
-                    'type': 'PLAYLIST'
-                },
-                {
-                    'entries': [
-                        {
-                            'id': 9,
-                            'track': {
-                                'id': 6,
-                                'title': 'Track5'
-                            }
-                        },
-                        {
-                            'id': 10,
-                            'track': {
-                                'id': 7,
-                                'title': 'Track6'
-                            }
-                        },
-                        {
-                            'id': 11,
-                            'track': {
-                                'id': 8,
-                                'title': 'Track7'
-                            }
-                        },
-                        {
-                            'id': 12,
-                            'track': {
-                                'id': 9,
-                                'title': 'Track8'
-                            }
-                        },
-                        {
-                            'id': 13,
-                            'track': {
-                                'id': 10,
-                                'title': 'Track9'
-                            }
-                        }
-                    ],
-                    'id': 4,
-                    'lastUpdatedOn': 1577840461,
-                    'name': 'Playlist3',
-                    'numTracks': 5,
-                    'starred': False,
-                    'topGenres': [
-                        {
-                            'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 3
-                        },
-                        {
-                            'genre': {
                                 'id': 11
                             },
-                            'numMatches': 2
+                            'numMatches': 3
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 3
                         }
                     ],
                     'type': 'PLAYLIST'
                 }
             ],
-            'total': 4
+            'total': 5
         }
     }
 }
@@ -597,6 +603,18 @@ snapshots['test_playlists_type_param 1'] = {
                     'entries': [
                     ],
                     'id': 1,
+                    'lastUpdatedOn': 1577840461,
+                    'name': 'Favorites',
+                    'numTracks': 0,
+                    'starred': True,
+                    'topGenres': [
+                    ],
+                    'type': 'SYSTEM'
+                },
+                {
+                    'entries': [
+                    ],
+                    'id': 2,
                     'lastUpdatedOn': 1577840461,
                     'name': 'Favorites',
                     'numTracks': 0,
@@ -636,7 +654,7 @@ snapshots['test_update_playlist 1'] = {
                     }
                 }
             ],
-            'id': 3,
+            'id': 4,
             'lastUpdatedOn': 1577840461,
             'name': 'NewPlaylist',
             'numTracks': 3,
@@ -644,13 +662,13 @@ snapshots['test_update_playlist 1'] = {
             'topGenres': [
                 {
                     'genre': {
-                        'id': 9
+                        'id': 11
                     },
                     'numMatches': 3
                 },
                 {
                     'genre': {
-                        'id': 10
+                        'id': 12
                     },
                     'numMatches': 3
                 }

--- a/backend/src/graphql/types/snapshots/snap_release_test.py
+++ b/backend/src/graphql/types/snapshots/snap_release_test.py
@@ -28,13 +28,13 @@ snapshots['test_add_artist_to_release 1'] = {
                 'topGenres': [
                     {
                         'genre': {
-                            'id': 9
+                            'id': 11
                         },
                         'numMatches': 2
                     },
                     {
                         'genre': {
-                            'id': 10
+                            'id': 12
                         },
                         'numMatches': 2
                     }
@@ -58,21 +58,21 @@ snapshots['test_add_artist_to_release 1'] = {
                 ],
                 'collages': [
                     {
-                        'id': 3,
+                        'id': 5,
                         'name': 'Collage1'
                     },
                     {
-                        'id': 4,
+                        'id': 6,
                         'name': 'Collage2'
                     }
                 ],
                 'genres': [
                     {
-                        'id': 9,
+                        'id': 11,
                         'name': 'Genre1'
                     },
                     {
-                        'id': 10,
+                        'id': 12,
                         'name': 'Genre2'
                     }
                 ],
@@ -82,7 +82,7 @@ snapshots['test_add_artist_to_release 1'] = {
                 'inInbox': False,
                 'labels': [
                     {
-                        'id': 6,
+                        'id': 8,
                         'name': 'Label1'
                     }
                 ],
@@ -259,7 +259,7 @@ snapshots['test_del_artist_from_release 1'] = {
                 'topGenres': [
                     {
                         'genre': {
-                            'id': 11
+                            'id': 13
                         },
                         'numMatches': 1
                     }
@@ -275,21 +275,21 @@ snapshots['test_del_artist_from_release 1'] = {
                 ],
                 'collages': [
                     {
-                        'id': 3,
+                        'id': 5,
                         'name': 'Collage1'
                     },
                     {
-                        'id': 4,
+                        'id': 6,
                         'name': 'Collage2'
                     }
                 ],
                 'genres': [
                     {
-                        'id': 9,
+                        'id': 11,
                         'name': 'Genre1'
                     },
                     {
-                        'id': 10,
+                        'id': 12,
                         'name': 'Genre2'
                     }
                 ],
@@ -299,7 +299,7 @@ snapshots['test_del_artist_from_release 1'] = {
                 'inInbox': False,
                 'labels': [
                     {
-                        'id': 6,
+                        'id': 8,
                         'name': 'Label1'
                     }
                 ],
@@ -401,21 +401,21 @@ snapshots['test_release 1'] = {
             ],
             'collages': [
                 {
-                    'id': 3,
+                    'id': 5,
                     'name': 'Collage1'
                 },
                 {
-                    'id': 4,
+                    'id': 6,
                     'name': 'Collage2'
                 }
             ],
             'genres': [
                 {
-                    'id': 9,
+                    'id': 11,
                     'name': 'Genre1'
                 },
                 {
-                    'id': 10,
+                    'id': 12,
                     'name': 'Genre2'
                 }
             ],
@@ -425,7 +425,7 @@ snapshots['test_release 1'] = {
             'inInbox': False,
             'labels': [
                 {
-                    'id': 6,
+                    'id': 8,
                     'name': 'Label1'
                 }
             ],
@@ -529,21 +529,21 @@ snapshots['test_releases 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         },
                         {
-                            'id': 4,
+                            'id': 6,
                             'name': 'Collage2'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -553,7 +553,7 @@ snapshots['test_releases 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -592,17 +592,17 @@ snapshots['test_releases 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -612,7 +612,7 @@ snapshots['test_releases 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -643,17 +643,17 @@ snapshots['test_releases 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -663,7 +663,7 @@ snapshots['test_releases 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -708,7 +708,7 @@ snapshots['test_releases 1'] = {
                     ],
                     'genres': [
                         {
-                            'id': 11,
+                            'id': 13,
                             'name': 'Genre3'
                         }
                     ],
@@ -718,7 +718,7 @@ snapshots['test_releases 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -759,7 +759,7 @@ snapshots['test_releases 1'] = {
                     ],
                     'genres': [
                         {
-                            'id': 11,
+                            'id': 13,
                             'name': 'Genre3'
                         }
                     ],
@@ -810,21 +810,21 @@ snapshots['test_releases_filter_artists 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         },
                         {
-                            'id': 4,
+                            'id': 6,
                             'name': 'Collage2'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -834,7 +834,7 @@ snapshots['test_releases_filter_artists 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -879,7 +879,7 @@ snapshots['test_releases_filter_artists 1'] = {
                     ],
                     'genres': [
                         {
-                            'id': 11,
+                            'id': 13,
                             'name': 'Genre3'
                         }
                     ],
@@ -889,7 +889,7 @@ snapshots['test_releases_filter_artists 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -946,21 +946,21 @@ snapshots['test_releases_filter_collections 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         },
                         {
-                            'id': 4,
+                            'id': 6,
                             'name': 'Collage2'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -970,7 +970,7 @@ snapshots['test_releases_filter_collections 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1009,17 +1009,17 @@ snapshots['test_releases_filter_collections 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1029,7 +1029,7 @@ snapshots['test_releases_filter_collections 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1060,17 +1060,17 @@ snapshots['test_releases_filter_collections 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1080,7 +1080,7 @@ snapshots['test_releases_filter_collections 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -1129,21 +1129,21 @@ snapshots['test_releases_filter_types 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         },
                         {
-                            'id': 4,
+                            'id': 6,
                             'name': 'Collage2'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1153,7 +1153,7 @@ snapshots['test_releases_filter_types 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1192,17 +1192,17 @@ snapshots['test_releases_filter_types 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1212,7 +1212,7 @@ snapshots['test_releases_filter_types 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1257,17 +1257,17 @@ snapshots['test_releases_pagination 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1277,7 +1277,7 @@ snapshots['test_releases_pagination 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1308,17 +1308,17 @@ snapshots['test_releases_pagination 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1328,7 +1328,7 @@ snapshots['test_releases_pagination 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -1377,21 +1377,21 @@ snapshots['test_releases_search 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         },
                         {
-                            'id': 4,
+                            'id': 6,
                             'name': 'Collage2'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1401,7 +1401,7 @@ snapshots['test_releases_search 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1450,21 +1450,21 @@ snapshots['test_releases_sort 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         },
                         {
-                            'id': 4,
+                            'id': 6,
                             'name': 'Collage2'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1474,7 +1474,7 @@ snapshots['test_releases_sort 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1513,17 +1513,17 @@ snapshots['test_releases_sort 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1533,7 +1533,7 @@ snapshots['test_releases_sort 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1564,17 +1564,17 @@ snapshots['test_releases_sort 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1584,7 +1584,7 @@ snapshots['test_releases_sort 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -1629,7 +1629,7 @@ snapshots['test_releases_sort 1'] = {
                     ],
                     'genres': [
                         {
-                            'id': 11,
+                            'id': 13,
                             'name': 'Genre3'
                         }
                     ],
@@ -1639,7 +1639,7 @@ snapshots['test_releases_sort 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -1680,7 +1680,7 @@ snapshots['test_releases_sort 1'] = {
                     ],
                     'genres': [
                         {
-                            'id': 11,
+                            'id': 13,
                             'name': 'Genre3'
                         }
                     ],
@@ -1779,7 +1779,7 @@ snapshots['test_releases_sort_desc 1'] = {
                     ],
                     'genres': [
                         {
-                            'id': 11,
+                            'id': 13,
                             'name': 'Genre3'
                         }
                     ],
@@ -1826,7 +1826,7 @@ snapshots['test_releases_sort_desc 1'] = {
                     ],
                     'genres': [
                         {
-                            'id': 11,
+                            'id': 13,
                             'name': 'Genre3'
                         }
                     ],
@@ -1836,7 +1836,7 @@ snapshots['test_releases_sort_desc 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -1879,17 +1879,17 @@ snapshots['test_releases_sort_desc 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1899,7 +1899,7 @@ snapshots['test_releases_sort_desc 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 7,
+                            'id': 9,
                             'name': 'Label2'
                         }
                     ],
@@ -1938,17 +1938,17 @@ snapshots['test_releases_sort_desc 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -1958,7 +1958,7 @@ snapshots['test_releases_sort_desc 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -1993,21 +1993,21 @@ snapshots['test_releases_sort_desc 1'] = {
                     ],
                     'collages': [
                         {
-                            'id': 3,
+                            'id': 5,
                             'name': 'Collage1'
                         },
                         {
-                            'id': 4,
+                            'id': 6,
                             'name': 'Collage2'
                         }
                     ],
                     'genres': [
                         {
-                            'id': 9,
+                            'id': 11,
                             'name': 'Genre1'
                         },
                         {
-                            'id': 10,
+                            'id': 12,
                             'name': 'Genre2'
                         }
                     ],
@@ -2017,7 +2017,7 @@ snapshots['test_releases_sort_desc 1'] = {
                     'inInbox': False,
                     'labels': [
                         {
-                            'id': 6,
+                            'id': 8,
                             'name': 'Label1'
                         }
                     ],
@@ -2064,21 +2064,21 @@ snapshots['test_update_release 1'] = {
             ],
             'collages': [
                 {
-                    'id': 3,
+                    'id': 5,
                     'name': 'Collage1'
                 },
                 {
-                    'id': 4,
+                    'id': 6,
                     'name': 'Collage2'
                 }
             ],
             'genres': [
                 {
-                    'id': 9,
+                    'id': 11,
                     'name': 'Genre1'
                 },
                 {
-                    'id': 10,
+                    'id': 12,
                     'name': 'Genre2'
                 }
             ],
@@ -2088,7 +2088,7 @@ snapshots['test_update_release 1'] = {
             'inInbox': False,
             'labels': [
                 {
-                    'id': 6,
+                    'id': 8,
                     'name': 'Label1'
                 }
             ],

--- a/backend/src/graphql/types/snapshots/snap_track_test.py
+++ b/backend/src/graphql/types/snapshots/snap_track_test.py
@@ -59,13 +59,13 @@ snapshots['test_add_artist_to_track 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
+                                'id': 11
                             },
                             'numMatches': 1
                         },
                         {
                             'genre': {
-                                'id': 10
+                                'id': 12
                             },
                             'numMatches': 1
                         }
@@ -176,19 +176,19 @@ snapshots['test_del_artist_from_track 1'] = {
                     'topGenres': [
                         {
                             'genre': {
-                                'id': 9
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
-                                'id': 10
-                            },
-                            'numMatches': 1
-                        },
-                        {
-                            'genre': {
                                 'id': 11
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 12
+                            },
+                            'numMatches': 1
+                        },
+                        {
+                            'genre': {
+                                'id': 13
                             },
                             'numMatches': 1
                         }

--- a/backend/src/graphql/types/track.py
+++ b/backend/src/graphql/types/track.py
@@ -8,14 +8,10 @@ from src.errors import NotFound
 from src.graphql.mutation import mutation
 from src.graphql.query import query
 from src.graphql.util import commit
-from src.library import artist
-from src.library import playlist_entry as pentry
-from src.library import release, track
+from src.library import artist, release, track
 from src.util import convert_keys_case, del_pagination_keys
 
 gql_track = ObjectType("Track")
-
-FAVORITES_PLAYLIST_ID = 1
 
 
 @query.field("track")
@@ -35,13 +31,9 @@ def resolve_tracks(obj: Any, info: GraphQLResolveInfo, **kwargs) -> dict:
     }
 
 
-@gql_track.field("favorited")
-def resolve_favorited(obj: track.T, info: GraphQLResolveInfo) -> bool:
-    return pentry.exists_playlist_and_track(
-        FAVORITES_PLAYLIST_ID,
-        obj.id,
-        info.context.db,
-    )
+@gql_track.field("inFavorites")
+def resolve_in_favorites(obj: track.T, info: GraphQLResolveInfo) -> bool:
+    return track.in_favorites(obj, info.context.user.id, info.context.db)
 
 
 @gql_track.field("release")

--- a/backend/src/graphql/types/track_test.py
+++ b/backend/src/graphql/types/track_test.py
@@ -35,11 +35,11 @@ async def test_track_not_found(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
-async def test_track_favorited(db: Connection, graphql_query, snapshot):
+async def test_track_in_favorites(db: Connection, graphql_query):
     query = """
         query {
             track(id: 1) {
-                favorited
+                inFavorites
             }
         }
     """
@@ -50,21 +50,21 @@ async def test_track_favorited(db: Connection, graphql_query, snapshot):
 
     success, data = await graphql_query(query)
     assert success is True
-    assert data["data"]["track"]["favorited"]
+    assert data["data"]["track"]["inFavorites"]
 
 
 @pytest.mark.asyncio
-async def test_track_favorited_false(graphql_query, snapshot):
+async def test_track_in_favorites_false(graphql_query):
     query = """
         query {
             track(id: 1) {
-                favorited
+                inFavorites
             }
         }
     """
     success, data = await graphql_query(query)
     assert success is True
-    assert not data["data"]["track"]["favorited"]
+    assert not data["data"]["track"]["inFavorites"]
 
 
 @pytest.mark.asyncio

--- a/backend/src/graphql/types/track_test.py
+++ b/backend/src/graphql/types/track_test.py
@@ -105,7 +105,7 @@ async def test_tracks_search(graphql_query, snapshot):
 async def test_tracks_filter_playlists(graphql_query, snapshot):
     query = """
         query {
-            tracks(playlistIds: [2]) {
+            tracks(playlistIds: [3]) {
                 total
                 results {
                     ...TrackFields

--- a/backend/src/graphql/types/user.py
+++ b/backend/src/graphql/types/user.py
@@ -6,15 +6,30 @@ from graphql.type import GraphQLResolveInfo
 from src.graphql.mutation import mutation
 from src.graphql.query import query
 from src.graphql.util import commit
-from src.library import user
+from src.library import user, collection, playlist
 
 gql_user = ObjectType("User")
 gql_token = ObjectType("Token")
 
 
 @query.field("user")
-def resolve_user(obj: Any, info: GraphQLResolveInfo) -> user.T:
+def resolve_user(_: Any, info: GraphQLResolveInfo) -> user.T:
     return info.context.user
+
+
+@gql_user.field("inboxCollectionId")
+def resolve_inbox_col_id(_: Any, info: GraphQLResolveInfo) -> int:
+    return collection.inbox_of(info.context.user.id, info.context.db).id
+
+
+@gql_user.field("favoritesCollectionId")
+def resolve_favorites_col_id(_: Any, info: GraphQLResolveInfo) -> int:
+    return collection.favorites_of(info.context.user.id, info.context.db).id
+
+
+@gql_user.field("favoritesPlaylistId")
+def resolve_favorites_ply_id(_: Any, info: GraphQLResolveInfo) -> int:
+    return playlist.favorites_of(info.context.user.id, info.context.db).id
 
 
 @mutation.field("updateUser")
@@ -38,5 +53,5 @@ def resolve_new_token(_, info: GraphQLResolveInfo) -> bytes:
 
 
 @gql_token.field("hex")
-def resolve_hex(obj: bytes, info: GraphQLResolveInfo) -> str:
+def resolve_hex(obj: bytes, _: GraphQLResolveInfo) -> str:
     return obj.hex()

--- a/backend/src/graphql/types/user.py
+++ b/backend/src/graphql/types/user.py
@@ -6,7 +6,7 @@ from graphql.type import GraphQLResolveInfo
 from src.graphql.mutation import mutation
 from src.graphql.query import query
 from src.graphql.util import commit
-from src.library import user, collection, playlist
+from src.library import collection, playlist, user
 
 gql_user = ObjectType("User")
 gql_token = ObjectType("Token")

--- a/backend/src/graphql/types/user_test.py
+++ b/backend/src/graphql/types/user_test.py
@@ -28,6 +28,25 @@ async def test_user(graphql_query, snapshot):
 
 
 @pytest.mark.asyncio
+async def test_user_collection_ids(graphql_query, snapshot):
+    success, data = await graphql_query(
+        """
+        query {
+            user {
+               inboxCollectionId
+               favoritesCollectionId
+               favoritesPlaylistId
+           }
+       }
+       """
+    )
+    assert success is True
+    assert data["data"]["user"]["inboxCollectionId"] == 1
+    assert data["data"]["user"]["favoritesCollectionId"] == 2
+    assert data["data"]["user"]["favoritesPlaylistId"] == 1
+
+
+@pytest.mark.asyncio
 async def test_update_user(db, graphql_query, snapshot):
     query = """
         mutation {

--- a/backend/src/indexer/__init__.py
+++ b/backend/src/indexer/__init__.py
@@ -1,9 +1,10 @@
 # flake8: noqa
 
+from src.config import config
+from src.tasks import huey
+
 from .covers import save_pending_covers
 from .scanner import scan_directories
-from src.tasks import huey
-from src.config import config
 
 
 def run_indexer() -> None:

--- a/backend/src/indexer/__init__.py
+++ b/backend/src/indexer/__init__.py
@@ -2,9 +2,16 @@
 
 from .covers import save_pending_covers
 from .scanner import scan_directories
+from src.tasks import huey
+from src.config import config
 
 
 def run_indexer() -> None:
     """Run the two stages of the indexer."""
     scan_directories()
     save_pending_covers()
+
+
+@huey.periodic_task(config.index_crontab)
+def indexer():
+    run_indexer()

--- a/backend/src/indexer/covers.py
+++ b/backend/src/indexer/covers.py
@@ -7,7 +7,7 @@ from typing import Generator, Optional
 
 from tagfiles import TagFile
 
-from src.constants import Constants
+from src.constants import constants
 from src.errors import Duplicate
 from src.library import image
 from src.util import database
@@ -200,10 +200,8 @@ def _save_image_file(data: bytes, extension: str) -> Path:
     :param extension: The file extension of the image.
     :return: The filepath that the image was saved to.
     """
-    cons = Constants()
-
     sha256sum = sha256(data).hexdigest()
-    filepath = cons.cover_art_dir / f"{sha256sum}.{extension}"
+    filepath = constants.cover_art_dir / f"{sha256sum}.{extension}"
 
     if filepath.exists():
         logger.debug("Embedded image already saved!")

--- a/backend/src/indexer/covers_test.py
+++ b/backend/src/indexer/covers_test.py
@@ -2,7 +2,7 @@ import shutil
 from pathlib import Path
 from sqlite3 import Connection
 
-from src.constants import TEST_DATA_PATH, Constants
+from src.constants import TEST_DATA_PATH, constants
 from src.fixtures.factory import Factory
 
 from .covers import save_pending_covers
@@ -46,6 +46,5 @@ def test_save_pending_covers(factory: Factory, db: Connection):
 
     save_pending_covers()
 
-    cons = Constants()
-    saved_covers = sorted([path.name for path in cons.cover_art_dir.iterdir()])
+    saved_covers = sorted([path.name for path in constants.cover_art_dir.iterdir()])
     assert len(saved_covers) == 4

--- a/backend/src/indexer/scanner.py
+++ b/backend/src/indexer/scanner.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from tagfiles import TagFile
 
-from src.config import Config
+from src.config import config
 from src.enums import ArtistRole, CollectionType, ReleaseType
 from src.errors import Duplicate
 from src.library import artist, collection, release, track
@@ -40,7 +40,7 @@ def scan_directories() -> None:
     Read the music directories to be indexed from the configuration and scan them for
     new files.
     """
-    music_directories = Config().music_directories
+    music_directories = config.music_directories
     logger.info(f"Found {len(music_directories)} directories to scan.")
 
     for dir_ in music_directories:

--- a/backend/src/indexer/scanner.py
+++ b/backend/src/indexer/scanner.py
@@ -175,7 +175,7 @@ def _fetch_or_create_release(tf: TagFile, conn: Connection) -> release.T:
     logger.debug(f"Created new release {rls.id} for track `{tf.path}`.")
 
     # Add release to the inbox and its label/genres.
-    _insert_into_inbox_collection(rls, conn)
+    _insert_into_inbox_collections(rls, conn)
     _insert_into_label_collection(rls, tf.label, conn)
     _insert_into_genre_collections(rls, tf.genre, conn)
 
@@ -226,18 +226,21 @@ def _fetch_or_create_artist(name: str, conn: Connection) -> artist.T:
         return e.entity
 
 
-def _insert_into_inbox_collection(rls: release.T, conn: Connection) -> None:
+def _insert_into_inbox_collections(rls: release.T, conn: Connection) -> None:
     """
-    Insert a release into the inbox collection.
+    Insert a release into all inbox collections.
 
     :param rls: The release to add to the inbox collection.
     :param conn: A connection to the database.
     """
-    logger.debug(f"Adding release {rls.id} to the inbox collection.")
-    # Inbox has ID 1--this is specified in the database schema.
-    inbox = collection.from_id(1, conn)
-    assert inbox is not None
-    collection.add_release(inbox, rls.id, conn)
+    logger.debug(f"Adding release {rls.id} to inbox collections.")
+    inboxes = collection.from_name_and_type(
+        name="Inbox",
+        type=CollectionType.SYSTEM,
+        conn=conn,
+    )
+    for inbox in inboxes:
+        collection.add_release(inbox, rls.id, conn)
 
 
 def _insert_into_label_collection(

--- a/backend/src/indexer/scanner_test.py
+++ b/backend/src/indexer/scanner_test.py
@@ -256,7 +256,7 @@ def test_insert_into_label_collection_existing(factory: Factory, db: Connection)
 def test_insert_into_label_collection_new(factory: Factory, db: Connection):
     rls = factory.release(conn=db)
     _insert_into_label_collection(rls, "asdf", db)
-    col = collection.from_name_and_type("asdf", CollectionType.LABEL, db)
+    col = collection.from_name_type_user("asdf", CollectionType.LABEL, db)
     assert col in release.collections(rls, db)
 
 
@@ -266,7 +266,7 @@ def test_insert_into_genre_collections(factory: Factory, db: Connection):
     _insert_into_genre_collections(rls, ["1, 2, 3", "4; 5"], db)
     collections = release.collections(rls, db)
     for genre in ["1", "2", "3", "4", "5"]:
-        col = collection.from_name_and_type(genre, CollectionType.GENRE, db)
+        col = collection.from_name_type_user(genre, CollectionType.GENRE, db)
         assert col in collections
 
 
@@ -276,7 +276,7 @@ def test_duplicate_genre(factory: Factory, db: Connection):
     _insert_into_genre_collections(rls, ["1, 2, 3", "2/3"], db)
     collections = release.collections(rls, db)
     for genre in ["1", "2", "3"]:
-        col = collection.from_name_and_type(genre, CollectionType.GENRE, db)
+        col = collection.from_name_type_user(genre, CollectionType.GENRE, db)
         assert col in collections
 
 

--- a/backend/src/indexer/scanner_test.py
+++ b/backend/src/indexer/scanner_test.py
@@ -17,7 +17,7 @@ from .scanner import (
     _fix_release_types,
     _get_release_type,
     _insert_into_genre_collections,
-    _insert_into_inbox_collection,
+    _insert_into_inbox_collections,
     _insert_into_label_collection,
     _split_genres,
     catalog_file,
@@ -230,14 +230,18 @@ def test_fetch_or_create_artist_duplicate(factory: Factory, db: Connection):
 
 
 def test_insert_into_inbox_collection(factory: Factory, db: Connection):
-    inbox = collection.from_id(1, db)
-    assert inbox is not None
+    # Create two new inboxes.
+    usr1, _ = factory.user(conn=db)
+    usr2, _ = factory.user(conn=db)
 
     rls = factory.release(conn=db)
-    assert rls not in collection.releases(inbox, db)
+    _insert_into_inbox_collections(rls, db)
 
-    _insert_into_inbox_collection(rls, db)
-    assert release.from_id(rls.id, db) in collection.releases(inbox, db)
+    inbox1 = collection.inbox_of(usr1.id, db)
+    inbox2 = collection.inbox_of(usr2.id, db)
+
+    assert rls in collection.releases(inbox1, db)
+    assert rls in collection.releases(inbox2, db)
 
 
 def test_insert_into_label_collection_nonexistent(factory: Factory, db: Connection):

--- a/backend/src/library/collection.py
+++ b/backend/src/library/collection.py
@@ -263,7 +263,7 @@ def create(
     :param conn: A connection to the database.
     :param starred: Whether the collection is starred or not.
     :param user_id: The ID of the user that this collection belongs to. Should be set
-                    for Personal collections; unset otherwise.
+                    for Personal and System collections; unset otherwise.
     :param override_immutable: Whether to allow creation of immutable collections. For
                                internal use.
     :return: The newly created collection.
@@ -275,12 +275,17 @@ def create(
     if type == CollectionType.SYSTEM and not override_immutable:
         raise InvalidCollectionType("Cannot create system collections.")
 
-    if type == CollectionType.PERSONAL and user_id is None:
-        raise InvalidArgument("Missing user_id argument for personal collections.")
-
-    if type != CollectionType.PERSONAL and user_id is not None:
+    if type in [CollectionType.PERSONAL, CollectionType.SYSTEM] and user_id is None:
         raise InvalidArgument(
-            "The user_id argument can only be set for personal collections."
+            "Missing user_id argument for personal/system collection."
+        )
+
+    if (
+        type not in [CollectionType.PERSONAL, CollectionType.SYSTEM]
+        and user_id is not None
+    ):
+        raise InvalidArgument(
+            "The user_id argument can only be set for personal/system collections."
         )
 
     if col := from_name_and_type(name, type, conn):

--- a/backend/src/library/collection.py
+++ b/backend/src/library/collection.py
@@ -651,7 +651,7 @@ def inbox_of(user_id: int, conn: Connection) -> T:
         user_id=user_id,
         conn=conn,
     )
-    if col is None:
+    if col is None:  # pragma: no cover
         raise DoesNotExist(f"No inbox exists for user {user_id}.")
     return col
 
@@ -671,7 +671,7 @@ def favorites_of(user_id: int, conn: Connection) -> T:
         user_id=user_id,
         conn=conn,
     )
-    if col is None:
+    if col is None:  # pragma: no cover
         raise DoesNotExist(f"No favorites collection exists for user {user_id}.")
     return col
 

--- a/backend/src/library/collection.py
+++ b/backend/src/library/collection.py
@@ -12,6 +12,7 @@ from src.errors import (
     DoesNotExist,
     Duplicate,
     Immutable,
+    InvalidArgument,
     InvalidCollectionType,
     NotFound,
 )
@@ -19,6 +20,7 @@ from src.util import make_fts_match_query, update_dataclass, without_key
 
 from . import image as libimage
 from . import release
+from . import user as libuser
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,9 @@ class T:
     starred: bool
     #:
     type: CollectionType
+    #: The ID of the user that the playlist belongs to. Only set for System and Personal
+    #  playlists.
+    user_id: Optional[int]
     #:
     num_releases: Optional[int] = None
     #:
@@ -247,6 +252,7 @@ def create(
     type: CollectionType,
     conn: Connection,
     starred: bool = False,
+    user_id: Optional[int] = None,
     override_immutable: bool = False,
 ) -> T:
     """
@@ -256,21 +262,36 @@ def create(
     :param type: The type of the collection.
     :param conn: A connection to the database.
     :param starred: Whether the collection is starred or not.
+    :param user_id: The ID of the user that this collection belongs to. Should be set
+                    for Personal collections; unset otherwise.
     :param override_immutable: Whether to allow creation of immutable collections. For
                                internal use.
     :return: The newly created collection.
     :raises Duplicate: If an collection with the same name and type already exists. The
                        duplicate collection is passed as the ``entity`` argument.
+    :raises InvalidArgument: If the user_id argument is passed with an non-personal
+                             collection type.
     """
     if type == CollectionType.SYSTEM and not override_immutable:
         raise InvalidCollectionType("Cannot create system collections.")
+
+    if type == CollectionType.PERSONAL and user_id is None:
+        raise InvalidArgument("Missing user_id argument for personal collections.")
+
+    if type != CollectionType.PERSONAL and user_id is not None:
+        raise InvalidArgument(
+            "The user_id argument can only be set for personal collections."
+        )
 
     if col := from_name_and_type(name, type, conn):
         raise Duplicate(f'Collection "{name}" already exists.', col)
 
     cursor = conn.execute(
-        "INSERT INTO music__collections (name, type, starred) VALUES (?, ?, ?)",
-        (name, type.value, starred),
+        """
+        INSERT INTO music__collections (name, type, starred, user_id)
+        VALUES (?, ?, ?, ?)
+        """,
+        (name, type.value, starred, user_id),
     )
 
     logger.info(
@@ -546,3 +567,14 @@ def image(col: T, conn: Connection) -> Optional[libimage.T]:
 
     logger.debug(f"Failed to fetch image for collection {col.id}.")
     return None
+
+
+def user(col: T, conn: Connection) -> Optional[libuser.T]:
+    """
+    Returns the user the collection belongs to, if it belongs to a user.
+
+    :param col: The collection whose user to fetch.
+    :param conn: A connection to the database.
+    :return: The user, if one exists.
+    """
+    return libuser.from_id(col.user_id, conn) if col.user_id else None

--- a/backend/src/library/collection_test.py
+++ b/backend/src/library/collection_test.py
@@ -83,11 +83,13 @@ def test_search_user(factory: Factory, db: Connection):
     col1 = factory.collection(type=CollectionType.PERSONAL, user=usr, conn=db)
     col2 = factory.collection(type=CollectionType.PERSONAL, user=usr, conn=db)
 
-    factory.collection(type=CollectionType.PERSONAL, user=unused_usr, conn=db)
-    factory.collection(conn=db)
+    col3 = factory.collection(type=CollectionType.PERSONAL, user=unused_usr, conn=db)
+    col4 = factory.collection(conn=db)
 
     cols = collection.search(db, user_ids=[usr.id])
-    assert {p.id for p in cols} == {col1.id, col2.id}
+    ids = [c.id for c in cols]
+    assert all(c.id in ids for c in [col1, col2])
+    assert not any(c.id in ids for c in [col3, col4])
 
 
 def test_search_page(factory: Factory, db: Connection):

--- a/backend/src/library/collection_test.py
+++ b/backend/src/library/collection_test.py
@@ -60,6 +60,23 @@ def test_from_name_type_user_failure(db: Connection):
     assert col2 is None
 
 
+def test_from_name_and_type(factory: Factory, db: Connection):
+    usr1, _ = factory.user(conn=db)
+    col1 = factory.collection(
+        name="test", type=CollectionType.SYSTEM, user=usr1, conn=db
+    )
+
+    usr2, _ = factory.user(conn=db)
+    col2 = factory.collection(
+        name="test", type=CollectionType.SYSTEM, user=usr2, conn=db
+    )
+
+    factory.collection(name="other", type=CollectionType.COLLAGE, conn=db)
+
+    cols = collection.from_name_and_type("test", CollectionType.SYSTEM, conn=db)
+    assert {c.id for c in cols} == {col1.id, col2.id}
+
+
 def test_search_all(factory: Factory, db: Connection):
     cols = {factory.collection(conn=db) for _ in range(5)}
     assert cols == set(collection.search(db))

--- a/backend/src/library/collection_test.py
+++ b/backend/src/library/collection_test.py
@@ -36,18 +36,18 @@ def test_from_id_failure(db: Connection):
     assert collection.from_id(90000, db) is None
 
 
-def test_from_name_and_type_success(factory: Factory, db: Connection):
+def test_from_name_type_user_success(factory: Factory, db: Connection):
     col = factory.collection(conn=db)
-    new_col = collection.from_name_and_type(col.name, col.type, db)
+    new_col = collection.from_name_type_user(col.name, col.type, db)
     assert new_col is not None
 
     assert col.name == new_col.name
     assert col.type == new_col.type
 
 
-def test_from_name_and_type_failure(db: Connection):
-    col1 = collection.from_name_and_type("Electronic", CollectionType.COLLAGE, db)
-    col2 = collection.from_name_and_type("Inb0x", CollectionType.SYSTEM, db)
+def test_from_name_type_user_failure(db: Connection):
+    col1 = collection.from_name_type_user("Electronic", CollectionType.COLLAGE, db)
+    col2 = collection.from_name_type_user("Inb0x", CollectionType.SYSTEM, db)
 
     assert col1 is None
     assert col2 is None

--- a/backend/src/library/collection_test.py
+++ b/backend/src/library/collection_test.py
@@ -326,3 +326,9 @@ def test_image(factory: Factory, db: Connection):
 def test_image_nonexistent(factory: Factory, db: Connection):
     col = factory.collection(conn=db)
     assert collection.image(col, db) is None
+
+
+def test_user(factory: Factory, db: Connection):
+    usr, _ = factory.user(conn=db)
+    col = factory.collection(user=usr, conn=db)
+    assert usr.id == collection.user(col, conn=db)

--- a/backend/src/library/collection_test.py
+++ b/backend/src/library/collection_test.py
@@ -330,5 +330,5 @@ def test_image_nonexistent(factory: Factory, db: Connection):
 
 def test_user(factory: Factory, db: Connection):
     usr, _ = factory.user(conn=db)
-    col = factory.collection(user=usr, conn=db)
-    assert usr.id == collection.user(col, conn=db)
+    col = factory.collection(user=usr, type=CollectionType.SYSTEM, conn=db)
+    assert usr.id == collection.user(col, conn=db).id

--- a/backend/src/library/collection_test.py
+++ b/backend/src/library/collection_test.py
@@ -331,4 +331,6 @@ def test_image_nonexistent(factory: Factory, db: Connection):
 def test_user(factory: Factory, db: Connection):
     usr, _ = factory.user(conn=db)
     col = factory.collection(user=usr, type=CollectionType.SYSTEM, conn=db)
-    assert usr.id == collection.user(col, conn=db).id
+    col_user = collection.user(col, conn=db)
+    assert col_user is not None
+    assert usr.id == col_user.id

--- a/backend/src/library/collection_test.py
+++ b/backend/src/library/collection_test.py
@@ -45,6 +45,13 @@ def test_from_name_type_user_success(factory: Factory, db: Connection):
     assert col.type == new_col.type
 
 
+def test_from_name_type_user_with_user_id(factory: Factory, db: Connection):
+    usr, _ = factory.user(conn=db)
+    col = factory.collection(conn=db, type=CollectionType.PERSONAL, user=usr)
+    new_col = collection.from_name_type_user(col.name, col.type, db, usr.id)
+    assert col == new_col
+
+
 def test_from_name_type_user_failure(db: Connection):
     col1 = collection.from_name_type_user("Electronic", CollectionType.COLLAGE, db)
     col2 = collection.from_name_type_user("Inb0x", CollectionType.SYSTEM, db)
@@ -58,7 +65,7 @@ def test_search_all(factory: Factory, db: Connection):
     assert cols == set(collection.search(db))
 
 
-def test_search_filters(factory: Factory, db: Connection):
+def test_search_types(factory: Factory, db: Connection):
     col = factory.collection(type=CollectionType.GENRE, conn=db)
     collections = collection.search(
         db,
@@ -67,6 +74,20 @@ def test_search_filters(factory: Factory, db: Connection):
     )
     assert len(collections) == 1
     assert collections[0].id == col.id
+
+
+def test_search_user(factory: Factory, db: Connection):
+    usr, _ = factory.user(conn=db)
+    unused_usr, _ = factory.user(conn=db)
+
+    col1 = factory.collection(type=CollectionType.PERSONAL, user=usr, conn=db)
+    col2 = factory.collection(type=CollectionType.PERSONAL, user=usr, conn=db)
+
+    factory.collection(type=CollectionType.PERSONAL, user=unused_usr, conn=db)
+    factory.collection(conn=db)
+
+    cols = collection.search(db, user_ids=[usr.id])
+    assert {p.id for p in cols} == {col1.id, col2.id}
 
 
 def test_search_page(factory: Factory, db: Connection):

--- a/backend/src/library/invite.py
+++ b/backend/src/library/invite.py
@@ -248,12 +248,9 @@ def _generate_code(conn: Connection) -> bytes:
         if not cursor.fetchone():
             return code
 
-        logger.debug("Invite code clashed with existing invite.")
+        logger.debug("Invite code clashed with existing invite.")  # pragma: no cover
 
     # If we do not find a suitable token after 64 cycles, raise an exception.
-    logger.info(
-        "Failed to generate invite code after 64 cycles o.O"
-    )  # pragma: no cover
-    raise CodeGenerationFailure(  # pragma: no cover
-        "Failed to generate invite code after 64 cycles o.O"
-    )
+    message = "Failed to generate invite code after 64 cycles o.O"  # pragma: no cover
+    logger.info(message)  # pragma: no cover
+    raise CodeGenerationFailure(message)  # pragma: no cover

--- a/backend/src/library/playlist.py
+++ b/backend/src/library/playlist.py
@@ -261,7 +261,7 @@ def create(
     :param conn: A connection to the database.
     :param starred: Whether the playlist is starred or not.
     :param user_id: The ID of the user that this playlist belongs to. Should be set for
-                    Personal playlists; unset otherwise.
+                    Personal and System playlists; unset otherwise.
     :param override_immutable: Whether to allow creation of immutable playlists. For
                                internal use.
     :return: The newly created playlist.
@@ -273,12 +273,14 @@ def create(
     if type == PlaylistType.SYSTEM and not override_immutable:
         raise InvalidPlaylistType("Cannot create system playlists.")
 
-    if type == PlaylistType.PERSONAL and user_id is None:
-        raise InvalidArgument("Missing user_id argument for personal collections.")
-
-    if type != PlaylistType.PERSONAL and user_id is not None:
+    if type in [PlaylistType.PERSONAL, PlaylistType.SYSTEM] and user_id is None:
         raise InvalidArgument(
-            "The user_id argument can only be set for personal collections."
+            "Missing user_id argument for personal/system collection."
+        )
+
+    if type not in [PlaylistType.PERSONAL, PlaylistType.SYSTEM] and user_id is not None:
+        raise InvalidArgument(
+            "The user_id argument can only be set for personal/system collections."
         )
 
     if ply := from_name_and_type(name, type, conn):
@@ -305,7 +307,7 @@ def update(ply: T, conn: Connection, **changes) -> T:
     in as a keyword argument. To keep the original value, do not pass in a keyword
     argument.
 
-    **Note: The type of a playlist cannot be changed.**
+    **Note: The type and user_id of a playlist cannot be changed.**
 
     :param ply: The playlist to update.
     :param conn: A connection to the database.

--- a/backend/src/library/playlist.py
+++ b/backend/src/library/playlist.py
@@ -16,7 +16,13 @@ from sqlite3 import Connection, Row
 from typing import Optional, Union
 
 from src.enums import CollectionType, PlaylistType
-from src.errors import Duplicate, Immutable, InvalidArgument, InvalidPlaylistType
+from src.errors import (
+    DoesNotExist,
+    Duplicate,
+    Immutable,
+    InvalidArgument,
+    InvalidPlaylistType,
+)
 from src.util import make_fts_match_query, update_dataclass, without_key
 
 from . import collection
@@ -494,3 +500,23 @@ def user(ply: T, conn: Connection) -> Optional[libuser.T]:
     :return: The user, if one exists.
     """
     return libuser.from_id(ply.user_id, conn) if ply.user_id else None
+
+
+def favorites_of(user_id: int, conn: Connection) -> T:
+    """
+    Return the favorites playlist of the passed-in user.
+
+    :param user_id: The ID of the user whose favorites to fetch.
+    :param conn: A connection to the database.
+    :return: The user's favorites playlist.
+    :raises DoesNotExist: If the inbox does not exist.
+    """
+    ply = from_name_type_user(
+        "Favorites",
+        PlaylistType.SYSTEM,
+        user_id=user_id,
+        conn=conn,
+    )
+    if ply is None:
+        raise DoesNotExist(f"No favorites playlist exists for user {user_id}.")
+    return ply

--- a/backend/src/library/playlist_test.py
+++ b/backend/src/library/playlist_test.py
@@ -47,6 +47,19 @@ def test_from_name_type_user_failure(db: Connection):
     assert ply is None
 
 
+def test_from_name_and_type(factory: Factory, db: Connection):
+    usr1, _ = factory.user(conn=db)
+    ply1 = factory.playlist(name="test", type=PlaylistType.SYSTEM, user=usr1, conn=db)
+
+    usr2, _ = factory.user(conn=db)
+    ply2 = factory.playlist(name="test", type=PlaylistType.SYSTEM, user=usr2, conn=db)
+
+    factory.playlist(name="other", type=PlaylistType.PLAYLIST, conn=db)
+
+    plys = playlist.from_name_and_type("test", PlaylistType.SYSTEM, conn=db)
+    assert {p.id for p in plys} == {ply1.id, ply2.id}
+
+
 def test_search_all(factory: Factory, db: Connection):
     plys = {factory.playlist(conn=db) for _ in range(5)}
     assert plys == set(playlist.search(db))

--- a/backend/src/library/playlist_test.py
+++ b/backend/src/library/playlist_test.py
@@ -35,6 +35,13 @@ def test_from_name_type_user_success(factory: Factory, db: Connection):
     assert ply == new_ply
 
 
+def test_from_name_type_user_with_user_id(factory: Factory, db: Connection):
+    usr, _ = factory.user(conn=db)
+    ply = factory.playlist(conn=db, type=PlaylistType.PERSONAL, user=usr)
+    new_ply = playlist.from_name_type_user(ply.name, ply.type, db, usr.id)
+    assert ply == new_ply
+
+
 def test_from_name_type_user_failure(db: Connection):
     ply = playlist.from_name_type_user("CCCCCC", PlaylistType.PLAYLIST, db)
     assert ply is None
@@ -50,6 +57,20 @@ def test_search_name(factory: Factory, db: Connection):
     plys = playlist.search(db, search="AaA")
     assert len(plys) == 1
     assert plys[0].name == "AAAAAA"
+
+
+def test_search_user(factory: Factory, db: Connection):
+    usr, _ = factory.user(conn=db)
+    unused_usr, _ = factory.user(conn=db)
+
+    ply1 = factory.playlist(type=PlaylistType.PERSONAL, user=usr, conn=db)
+    ply2 = factory.playlist(type=PlaylistType.PERSONAL, user=usr, conn=db)
+
+    factory.playlist(type=PlaylistType.PERSONAL, user=unused_usr, conn=db)
+    factory.playlist(conn=db)
+
+    plys = playlist.search(db, user_ids=[usr.id])
+    assert {p.id for p in plys} == {ply1.id, ply2.id}
 
 
 def test_search_one(factory: Factory, db: Connection):

--- a/backend/src/library/playlist_test.py
+++ b/backend/src/library/playlist_test.py
@@ -66,11 +66,13 @@ def test_search_user(factory: Factory, db: Connection):
     ply1 = factory.playlist(type=PlaylistType.PERSONAL, user=usr, conn=db)
     ply2 = factory.playlist(type=PlaylistType.PERSONAL, user=usr, conn=db)
 
-    factory.playlist(type=PlaylistType.PERSONAL, user=unused_usr, conn=db)
-    factory.playlist(conn=db)
+    ply3 = factory.playlist(type=PlaylistType.PERSONAL, user=unused_usr, conn=db)
+    ply3 = factory.playlist(conn=db)
 
     plys = playlist.search(db, user_ids=[usr.id])
-    assert {p.id for p in plys} == {ply1.id, ply2.id}
+    ids = [p.id for p in plys]
+    assert all(p.id in ids for p in [ply1, ply2])
+    assert not any(p.id in ids for p in [ply3, ply3])
 
 
 def test_search_one(factory: Factory, db: Connection):

--- a/backend/src/library/playlist_test.py
+++ b/backend/src/library/playlist_test.py
@@ -29,14 +29,14 @@ def test_from_id_failure(db: Connection):
     assert playlist.from_id(90000, db) is None
 
 
-def test_from_name_and_type_success(factory: Factory, db: Connection):
+def test_from_name_type_user_success(factory: Factory, db: Connection):
     ply = factory.playlist(conn=db)
-    new_ply = playlist.from_name_and_type(ply.name, ply.type, db)
+    new_ply = playlist.from_name_type_user(ply.name, ply.type, db)
     assert ply == new_ply
 
 
-def test_from_name_and_type_failure(db: Connection):
-    ply = playlist.from_name_and_type("CCCCCC", PlaylistType.PLAYLIST, db)
+def test_from_name_type_user_failure(db: Connection):
+    ply = playlist.from_name_type_user("CCCCCC", PlaylistType.PLAYLIST, db)
     assert ply is None
 
 

--- a/backend/src/library/release.py
+++ b/backend/src/library/release.py
@@ -33,10 +33,6 @@ class T:
     release_year: Optional[int]
     #: The number of tracks that this release has.
     num_tracks: int
-    #: Whether this release is in the inbox collection.
-    in_inbox: bool
-    #: Whether this release is in the favorites collection.
-    in_favorites: bool
     #: The track rating (if exists, in the interval [1, 10]).
     rating: Optional[int]
     # The total runtime of the release (sum of track durations).
@@ -70,8 +66,6 @@ def from_row(row: Union[dict, Row]) -> T:
             row,
             runtime=row["runtime"] or 0,
             release_type=ReleaseType(row["release_type"]),
-            in_inbox=False,  # bool(row["in_inbox"]),
-            in_favorites=False,  # bool(row["in_favorites"]),
         )
     )
 
@@ -89,17 +83,7 @@ def from_id(id: int, conn: Connection) -> Optional[T]:
         SELECT
             rls.*,
             COUNT(trks.id) AS num_tracks,
-            SUM(trks.duration) as runtime,
-            (
-                SELECT 1
-                FROM music__collections_releases
-                WHERE release_id = rls.id AND collection_id = 1
-            ) AS in_inbox,
-            (
-                SELECT 1
-                FROM music__collections_releases
-                WHERE release_id = rls.id AND collection_id = 2
-            ) AS in_favorites
+            SUM(trks.duration) as runtime
         FROM music__releases AS rls
             LEFT JOIN music__tracks AS trks ON trks.release_id = rls.id
         WHERE rls.id = ?
@@ -180,17 +164,7 @@ def search(
         SELECT
             rls.*,
             COUNT(trks.id) AS num_tracks,
-            SUM(trks.duration) AS runtime,
-            (
-                SELECT 1
-                FROM music__collections_releases
-                WHERE release_id = rls.id AND collection_id = 1
-            ) AS in_inbox,
-            (
-                SELECT 1
-                FROM music__collections_releases
-                WHERE release_id = rls.id AND collection_id = 2
-            ) AS in_favorites
+            SUM(trks.duration) AS runtime
         FROM music__releases AS rls
             JOIN music__releases__fts AS fts ON fts.rowid = rls.id
             LEFT JOIN music__tracks AS trks ON trks.release_id = rls.id
@@ -479,17 +453,7 @@ def _find_duplicate_release(
         SELECT
             rls.*,
             COUNT(trks.id) AS num_tracks,
-            SUM (trks.duration) AS runtime,
-            (
-                SELECT 1
-                FROM music__collections_releases
-                WHERE release_id = rls.id AND collection_id = 1
-            ) AS in_inbox,
-            (
-                SELECT 1
-                FROM music__collections_releases
-                WHERE release_id = rls.id AND collection_id = 2
-            ) AS in_favorites
+            SUM (trks.duration) AS runtime
         FROM music__releases AS rls
         LEFT JOIN music__tracks AS trks ON trks.release_id = rls.id
         WHERE rls.title = ?
@@ -574,6 +538,34 @@ def update(rls: T, conn: Connection, **changes) -> T:
     logger.info(f"Updated release {rls.id} with {changes}.")
 
     return update_dataclass(rls, **changes)
+
+
+def in_inbox(rls: T, user_id: int, conn: Connection) -> bool:
+    """
+    Return whether this release is in the inbox of the passed-in user.
+
+    :param rls: The provided release.
+    :param user_id: The ID of the user whose inbox to check.
+    :param conn: A connection to the database.
+    :return: Whether the release is in the user's inbox.
+    :raises DoesNotExist: If the user's inbox does not exist.
+    """
+    inbox = collection.inbox_of(user_id, conn)
+    return collection.has_release(inbox, rls.id, conn)
+
+
+def in_favorites(rls: T, user_id: int, conn: Connection) -> bool:
+    """
+    Return whether this release is in the favorites of the passed-in user.
+
+    :param rls: The provided release.
+    :param user_id: The ID of the user whose favorites to check.
+    :param conn: A connection to the database.
+    :return: Whether the release is in the user's favorites.
+    :raises DoesNotExist: If the user's favorites does not exist.
+    """
+    inbox = collection.favorites_of(user_id, conn)
+    return collection.has_release(inbox, rls.id, conn)
 
 
 def tracks(rls: T, conn: Connection) -> list[track.T]:

--- a/backend/src/library/release.py
+++ b/backend/src/library/release.py
@@ -70,8 +70,8 @@ def from_row(row: Union[dict, Row]) -> T:
             row,
             runtime=row["runtime"] or 0,
             release_type=ReleaseType(row["release_type"]),
-            in_inbox=bool(row["in_inbox"]),
-            in_favorites=bool(row["in_favorites"]),
+            in_inbox=False,  # bool(row["in_inbox"]),
+            in_favorites=False,  # bool(row["in_favorites"]),
         )
     )
 

--- a/backend/src/library/release_test.py
+++ b/backend/src/library/release_test.py
@@ -383,8 +383,12 @@ def test_release_collections(factory: Factory, db: Connection):
 
 def test_release_collections_filter_type(factory: Factory, db: Connection):
     rls = factory.release(conn=db)
+    usr, _ = factory.user(conn=db)
 
-    cols = [factory.collection(type=CollectionType.SYSTEM, conn=db) for _ in range(2)]
+    cols = [
+        factory.collection(type=CollectionType.SYSTEM, user=usr, conn=db)
+        for _ in range(2)
+    ]
     for _ in range(3):
         cols.append(factory.collection(type=CollectionType.COLLAGE, conn=db))
 

--- a/backend/src/library/track.py
+++ b/backend/src/library/track.py
@@ -11,7 +11,7 @@ from src.enums import ArtistRole, TrackSort
 from src.errors import AlreadyExists, DoesNotExist, Duplicate, NotFound
 from src.util import make_fts_match_query, update_dataclass, without_key
 
-from . import artist
+from . import artist, playlist, playlist_entry
 from . import release as librelease
 
 logger = logging.getLogger(__name__)
@@ -455,6 +455,20 @@ def update(trk: T, conn: Connection, **changes) -> T:
     logger.info(f"Updated track {trk.id} with {changes}.")
 
     return update_dataclass(trk, **changes)
+
+
+def in_favorites(trk: T, user_id: int, conn: Connection) -> bool:
+    """
+    Return whether this track is in the favorites of the passed-in user.
+
+    :param trk: The provided track.
+    :param user_id: The ID of the user whose favorites to check.
+    :param conn: A connection to the database.
+    :return: Whether the track is in the user's favorites.
+    :raises DoesNotExist: If the user's favorites does not exist.
+    """
+    favorites = playlist.favorites_of(user_id, conn)
+    return playlist_entry.exists_playlist_and_track(favorites.id, trk.id, conn)
 
 
 def release(trk: T, conn: Connection) -> librelease.T:

--- a/backend/src/library/user.py
+++ b/backend/src/library/user.py
@@ -174,6 +174,7 @@ def _create_system_collections_and_playlists(user_id: int, conn: Connection) -> 
             name,
             CollectionType.SYSTEM,
             user_id=user_id,
+            starred=True,
             conn=conn,
             override_immutable=True,
         )
@@ -182,6 +183,7 @@ def _create_system_collections_and_playlists(user_id: int, conn: Connection) -> 
         "Favorites",
         PlaylistType.SYSTEM,
         user_id=user_id,
+        starred=True,
         conn=conn,
         override_immutable=True,
     )

--- a/backend/src/library/user.py
+++ b/backend/src/library/user.py
@@ -162,6 +162,7 @@ def create(nickname: str, conn: Connection) -> tuple[T, bytes]:
     logger.info(f"Created user {nickname} with ID {cursor.lastrowid}.")
 
     _create_system_collections_and_playlists(cursor.lastrowid, conn)
+    # _populate_inbox.schedule(args=(cursor.lastrowid,))
 
     usr = from_id(cursor.lastrowid, conn)
     assert usr is not None

--- a/backend/src/library/user.py
+++ b/backend/src/library/user.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from src.tasks import huey
 import logging
 import secrets
 import string
@@ -12,6 +11,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from src.enums import CollectionType, PlaylistType
 from src.errors import InvalidNickname, TokenGenerationFailure
+from src.tasks import huey
 from src.util import database, update_dataclass
 
 from . import collection

--- a/backend/src/library/user.py
+++ b/backend/src/library/user.py
@@ -297,10 +297,9 @@ def _generate_token(conn: Connection) -> tuple[bytes, bytes]:
         if not cursor.fetchone():
             return token, prefix
 
-        logger.debug("Token prefix clashed with existing token.")
+        logger.debug("Token prefix clashed with existing token.")  # pragma: no cover
 
     # If we do not find a suitable token after 64 cycles, raise an exception.
-    logger.info("Failed to generate token after 64 cycles o.O")  # pragma: no cover
-    raise TokenGenerationFailure(  # pragma: no cover
-        "Failed to generate token after 64 cycles o.O"
-    )
+    message = "Failed to generate token after 64 cycles o.O"  # pragma: no cover
+    logger.info(message)  # pragma: no cover
+    raise TokenGenerationFailure(message)  # pragma: no cover

--- a/backend/src/library/user_test.py
+++ b/backend/src/library/user_test.py
@@ -6,7 +6,7 @@ from werkzeug.security import check_password_hash
 from src.errors import InvalidNickname
 from src.fixtures.factory import Factory
 
-from . import user, collection
+from . import collection, user
 
 
 def test_exists(factory: Factory, db: Connection):

--- a/backend/src/library/user_test.py
+++ b/backend/src/library/user_test.py
@@ -6,7 +6,7 @@ from werkzeug.security import check_password_hash
 from src.errors import InvalidNickname
 from src.fixtures.factory import Factory
 
-from . import user
+from . import user, collection
 
 
 def test_exists(factory: Factory, db: Connection):
@@ -45,7 +45,7 @@ def test_from_token_success(factory: Factory, db: Connection):
 
 
 def test_from_token_failure_but_correct_prefix(factory: Factory, db: Connection):
-    usr, token = factory.user(conn=db)
+    _, token = factory.user(conn=db)
     new_token = token[: user.PREFIX_LENGTH] + b"0" * (
         user.TOKEN_LENGTH - user.PREFIX_LENGTH
     )
@@ -58,6 +58,19 @@ def test_from_token_failure(db: Connection):
 
 def test_from_token_bad_length(db: Connection):
     assert user.from_token(b"0" * 100, db) is None
+
+
+def test_populate_inbox(factory: Factory, db: Connection):
+    usr, _ = user.create("neW1", db)
+    for _ in range(12):
+        factory.release(conn=db)
+
+    db.commit()
+
+    user._populate_inbox.call_local(usr.id)
+
+    inbox = collection.inbox_of(usr.id, conn=db)
+    assert len(collection.releases(inbox, conn=db)) == 12
 
 
 def test_create_user_success(db: Connection):

--- a/backend/src/migrations/database.py
+++ b/backend/src/migrations/database.py
@@ -1,13 +1,11 @@
 from yoyo import get_backend, read_migrations
 
-from src.constants import Constants
+from src.constants import constants
 
 
 def run_database_migrations():
-    cons = Constants()
-
-    db_backend = get_backend(f"sqlite:///{cons.database_path}")
-    db_migrations = read_migrations(str(cons.migrations_path))
+    db_backend = get_backend(f"sqlite:///{constants.database_path}")
+    db_migrations = read_migrations(str(constants.migrations_path))
 
     with db_backend.lock():
         db_backend.apply_migrations(db_backend.to_apply(db_migrations))

--- a/backend/src/migrations/database_test.py
+++ b/backend/src/migrations/database_test.py
@@ -2,7 +2,7 @@ import sqlite3
 
 from yoyo import get_backend, read_migrations
 
-from src.constants import Constants
+from src.constants import constants
 from src.util import freeze_database_time
 
 from .database import run_database_migrations
@@ -26,9 +26,8 @@ def test_migrations(isolated_dir):
     cause an error. Basically, ladder our way up through the migration
     chain.
     """
-    cons = Constants()
     backend = get_backend(f"sqlite:///{isolated_dir / 'db.sqlite3'}")
-    migrations = read_migrations(str(cons.migrations_path))
+    migrations = read_migrations(str(constants.migrations_path))
 
     for mig in migrations:
         backend.apply_one(mig)

--- a/backend/src/migrations/sql/20200828_01_fmt5z.sql
+++ b/backend/src/migrations/sql/20200828_01_fmt5z.sql
@@ -112,10 +112,14 @@ CREATE TABLE music__collections (
     name VARCHAR COLLATE 'NOCASE' NOT NULL,
     starred BOOLEAN NOT NULL DEFAULT 0 CHECK (starred IN (0, 1)),
     type INTEGER NOT NULL,
+    user_id INTEGER,
     last_updated_on TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (type) REFERENCES music__collection_types__enum(id),
-    UNIQUE (name, type)
+    FOREIGN KEY (user_id) REFERENCES system__users(id) ON DELETE CASCADE,
+    UNIQUE (name, type, user_id),
+    -- Assert that all System & Personal collections have a user ID attached.
+    CHECK (type NOT IN (1, 2) OR user_id IS NOT NULL)
 );
 
 CREATE INDEX music__collections__sorting__idx
@@ -130,9 +134,10 @@ CREATE TABLE music__collection_types__enum (
 
 INSERT INTO music__collection_types__enum (id, type)
     VALUES (1, 'System'),
-           (2, 'Collage'),
-           (3, 'Label'),
-           (4, 'Genre');
+           (2, 'Personal'),
+           (3, 'Collage'),
+           (4, 'Label'),
+           (5, 'Genre');
 
 CREATE TABLE music__collections_releases (
     collection_id INTEGER NOT NULL,
@@ -148,10 +153,14 @@ CREATE TABLE music__playlists (
     name VARCHAR COLLATE 'NOCASE' NOT NULL,
     starred BOOLEAN NOT NULL DEFAULT 0 CHECK (starred IN (0, 1)),
     type INTEGER NOT NULL,
+    user_id INTEGER,
     last_updated_on TIMESTAMP DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (type) REFERENCES music__playlist_types__enum(id),
-    UNIQUE (name, type)
+    FOREIGN KEY (user_id) REFERENCES system__users(id) ON DELETE CASCADE,
+    UNIQUE (name, type, user_id),
+    -- Assert that all System & Personal playlists have a user ID attached.
+    CHECK (type NOT IN (1, 2) OR user_id IS NOT NULL)
 );
 
 CREATE INDEX music__playlists__sorting__idx
@@ -166,7 +175,8 @@ CREATE TABLE music__playlist_types__enum (
 
 INSERT INTO music__playlist_types__enum (id, type)
     VALUES (1, 'System'),
-           (2, 'Playlist');
+           (2, 'Personal'),
+           (3, 'Playlist');
 
 CREATE TABLE music__playlists_tracks (
     id INTEGER NOT NULL,
@@ -535,12 +545,3 @@ INSERT INTO music__artists (id, name) VALUES (1, 'Unknown Artist');
 
 -- Assign the unknown artist to the unknown release.
 INSERT INTO music__releases_artists (release_id, artist_id) VALUES (1, 1);
-
--- Insert a system inbox collection.
-INSERT INTO music__collections (id, name, type, starred)
-    VALUES (1, 'Inbox', 1, 1),
-           (2, 'Favorites', 1, 1);
-
--- Insert a system inbox playlist.
-INSERT INTO music__playlists (id, name, type, starred)
-    VALUES (1, 'Favorites', 1, 1);

--- a/backend/src/services.py
+++ b/backend/src/services.py
@@ -8,13 +8,11 @@ The services are:
 
 import asyncio
 
-from huey import SqliteHuey
 from huey.consumer_options import ConsumerConfig
 from hypercorn.asyncio import serve
 from hypercorn.config import Config
 
-from src.constants import constants
-from src.tasks import schedule_tasks
+from src.tasks import huey
 from src.webserver.app import create_app
 
 
@@ -29,9 +27,6 @@ def start_webserver(host: int, port: int) -> None:
 
 def start_task_queue(num_workers: int) -> None:
     """Start the Huey task queue."""
-    task_queue = SqliteHuey(filename=constants.huey_path)
-    schedule_tasks(task_queue)
-
     config = ConsumerConfig(workers=num_workers)
-    consumer = task_queue.create_consumer(**config.values)
+    consumer = huey.create_consumer(**config.values)
     consumer.run()

--- a/backend/src/services.py
+++ b/backend/src/services.py
@@ -13,7 +13,7 @@ from huey.consumer_options import ConsumerConfig
 from hypercorn.asyncio import serve
 from hypercorn.config import Config
 
-from src.constants import Constants
+from src.constants import constants
 from src.tasks import schedule_tasks
 from src.webserver.app import create_app
 
@@ -29,9 +29,7 @@ def start_webserver(host: int, port: int) -> None:
 
 def start_task_queue(num_workers: int) -> None:
     """Start the Huey task queue."""
-    cons = Constants()
-
-    task_queue = SqliteHuey(filename=cons.huey_path)
+    task_queue = SqliteHuey(filename=constants.huey_path)
     schedule_tasks(task_queue)
 
     config = ConsumerConfig(workers=num_workers)

--- a/backend/src/services.py
+++ b/backend/src/services.py
@@ -12,7 +12,7 @@ from huey.consumer_options import ConsumerConfig
 from hypercorn.asyncio import serve
 from hypercorn.config import Config
 
-from src.tasks import huey
+from src.tasks import huey, schedule_tasks
 from src.webserver.app import create_app
 
 
@@ -27,6 +27,8 @@ def start_webserver(host: int, port: int) -> None:
 
 def start_task_queue(num_workers: int) -> None:
     """Start the Huey task queue."""
+    schedule_tasks()
+
     config = ConsumerConfig(workers=num_workers)
     consumer = huey.create_consumer(**config.values)
     consumer.run()

--- a/backend/src/tasks.py
+++ b/backend/src/tasks.py
@@ -1,19 +1,19 @@
 import logging
 
-from huey import Huey
+from huey import SqliteHuey
 
 from src.config import config
+from src.constants import constants
 from src.indexer import run_indexer
 
 logger = logging.getLogger(__name__)
 
 
-def schedule_tasks(huey: Huey) -> None:
-    """
-    Schedule the recurring tasks.
+huey = SqliteHuey(filename=constants.huey_path)
 
-    :param huey: The Huey instance to schedule the tasks on.
-    """
-    logger.debug("Scheduling periodic tasks.")
+logger.debug("Scheduling periodic tasks.")
 
-    huey.periodic_task(config.index_crontab)(run_indexer)
+
+@huey.periodic_task(config.index_crontab)
+def indexer():
+    run_indexer()

--- a/backend/src/tasks.py
+++ b/backend/src/tasks.py
@@ -7,7 +7,6 @@ from src.constants import constants
 logger = logging.getLogger(__name__)
 
 
-print(f"{constants.huey_path=}")
 huey = SqliteHuey(filename=constants.huey_path)
 
 

--- a/backend/src/tasks.py
+++ b/backend/src/tasks.py
@@ -2,18 +2,18 @@ import logging
 
 from huey import SqliteHuey
 
-from src.config import config
 from src.constants import constants
-from src.indexer import run_indexer
 
 logger = logging.getLogger(__name__)
 
 
+print(f"{constants.huey_path=}")
 huey = SqliteHuey(filename=constants.huey_path)
 
-logger.debug("Scheduling periodic tasks.")
 
-
-@huey.periodic_task(config.index_crontab)
-def indexer():
-    run_indexer()
+def schedule_tasks():
+    """
+    This function imports the periodic tasks declared across the application.
+    """
+    # IDK if this actually works but it should!
+    import src.indexer  # noqa

--- a/backend/src/tasks.py
+++ b/backend/src/tasks.py
@@ -2,7 +2,7 @@ import logging
 
 from huey import Huey
 
-from src.config import Config
+from src.config import config
 from src.indexer import run_indexer
 
 logger = logging.getLogger(__name__)
@@ -16,5 +16,4 @@ def schedule_tasks(huey: Huey) -> None:
     """
     logger.debug("Scheduling periodic tasks.")
 
-    config = Config()
     huey.periodic_task(config.index_crontab)(run_indexer)

--- a/backend/src/tasks_test.py
+++ b/backend/src/tasks_test.py
@@ -1,10 +1,7 @@
-from huey import MemoryHuey
-
 from src.tasks import schedule_tasks
 
 
 def test_schedule_tasks(seed_data):
     # We want to make sure that this doesn't raise an exception... with respect to the
     # actual running of the tasks, well, I hope the server is correctly configured!
-    huey = MemoryHuey()
-    schedule_tasks(huey)
+    schedule_tasks()

--- a/backend/src/util.py
+++ b/backend/src/util.py
@@ -9,7 +9,7 @@ from sqlite3 import Connection
 from string import ascii_uppercase
 from typing import Any, Iterable, Union
 
-from src.constants import Constants
+from src.constants import constants
 
 logger = logging.getLogger(__name__)
 
@@ -36,10 +36,9 @@ def raw_database(check_same_thread: bool = True) -> Connection:
                               connection.
     :return: A connection to the database.
     """
-    cons = Constants()
-    logger.debug(f"Opening a connection to database {cons.database_path}.")
+    logger.debug(f"Opening a connection to database {constants.database_path}.")
     conn = sqlite3.connect(
-        cons.database_path,
+        constants.database_path,
         detect_types=sqlite3.PARSE_DECLTYPES,
         check_same_thread=check_same_thread,
     )

--- a/backend/src/util.py
+++ b/backend/src/util.py
@@ -1,6 +1,5 @@
 import logging
 import sqlite3
-import sys
 from contextlib import contextmanager
 from dataclasses import asdict
 from hashlib import sha256

--- a/backend/src/util.py
+++ b/backend/src/util.py
@@ -9,7 +9,7 @@ from sqlite3 import Connection
 from string import ascii_uppercase
 from typing import Any, Iterable, Union
 
-from src.constants import constants
+from src.constants import IS_PYTEST, constants
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ def raw_database(check_same_thread: bool = True) -> Connection:
 
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON")
-    if "pytest" in sys.modules:
+    if IS_PYTEST:
         freeze_database_time(conn)
 
     return conn

--- a/backend/src/webserver/app.py
+++ b/backend/src/webserver/app.py
@@ -11,7 +11,7 @@ import quart
 from quart import Quart, Response
 from werkzeug.exceptions import HTTPException
 
-from src.constants import Constants
+from src.constants import constants
 from src.util import database, raw_database
 from src.webserver.routes import dev, files, graphql, register, session
 
@@ -32,11 +32,9 @@ def create_app() -> Quart:
     """
     logger.debug("Creating Quart app.")
 
-    cons = Constants()
-
     app = Quart(
         __name__,
-        static_folder=str(cons.built_frontend_dir),
+        static_folder=str(constants.built_frontend_dir),
         static_url_path="/",
     )
 

--- a/frontend/src/components/Tracklist/Track.tsx
+++ b/frontend/src/components/Tracklist/Track.tsx
@@ -33,7 +33,7 @@ export const Track: ITrackComponent = ({
   const [unfavoriteTrack] = usePlaylistsUnfavoriteTrackMutation();
 
   const toggleFavorite = async (): Promise<void> => {
-    const toggleFunc = track.favorited ? unfavoriteTrack : favoriteTrack;
+    const toggleFunc = track.inFavorites ? unfavoriteTrack : favoriteTrack;
     await toggleFunc({ variables: { trackId: track.id } });
   };
 
@@ -50,11 +50,11 @@ export const Track: ITrackComponent = ({
         css={[
           tw`flex-none flex items-center absolute top-0 left-0`,
           tw`px-3 cursor-pointer h-full`,
-          track.favorited
+          track.inFavorites
             ? tw`text-primary-500 fill-current hover:(text-gray-500 stroke-current)`
             : tw`text-gray-500 stroke-current hover:(text-primary-400 fill-current)`,
         ]}
-        title={`${track.favorited ? 'Unfavorite' : 'Favorite'} this track!`}
+        title={`${track.inFavorites ? 'Unfavorite' : 'Favorite'} this track!`}
         onClick={toggleFavorite}
       >
         <Icon icon="star-small" tw="w-6 md:w-5" />
@@ -103,7 +103,7 @@ gql`
       }
       track {
         id
-        favorited
+        inFavorites
       }
     }
   }
@@ -119,7 +119,7 @@ gql`
       }
       track {
         id
-        favorited
+        inFavorites
       }
     }
   }

--- a/frontend/src/graphql/fragments.gql
+++ b/frontend/src/graphql/fragments.gql
@@ -74,7 +74,7 @@ fragment TrackFields on Track {
   duration
   trackNumber
   discNumber
-  favorited
+  inFavorites
 
   release {
     id

--- a/frontend/src/graphql/index.ts
+++ b/frontend/src/graphql/index.ts
@@ -61,6 +61,8 @@ export type ICollection = {
   releases: Array<IRelease>;
   /** The top genres of the collection, compiled from its releases. */
   topGenres: Array<ITopGenre>;
+  /** The user the collection belongs to. */
+  user: Maybe<IUser>;
 };
 
 export type ICollectionAndRelease = {
@@ -284,6 +286,8 @@ export type IPlaylist = {
   entries: Array<IPlaylistEntry>;
   /** The top genres of the playlist, compiled from its tracks. */
   topGenres: Array<ITopGenre>;
+  /** The user the playlist belongs to. */
+  user: Maybe<IUser>;
 };
 
 export type IPlaylistAndTrack = {
@@ -332,8 +336,8 @@ export type IQuery = {
   collections: ICollections;
   /** Fetch a collection by ID. */
   collection: ICollection;
-  /** Fetch a collection by name and type. */
-  collectionFromNameAndType: ICollection;
+  /** Fetch a collection by name, type, and user. */
+  collectionFromNameTypeUser: ICollection;
   /** Fetch invites. */
   invites: IInvites;
   /** Fetch invites by ID. */
@@ -342,8 +346,8 @@ export type IQuery = {
   playlists: IPlaylists;
   /** Fetch a playlist by ID. */
   playlist: IPlaylist;
-  /** Fetch a playlist by name and type. */
-  playlistFromNameAndType: IPlaylist;
+  /** Fetch a playlist by name, type, and user. */
+  playlistFromNameTypeUser: IPlaylist;
   /** Search releases. */
   releases: IReleases;
   /** Fetch a release by ID. */
@@ -387,9 +391,10 @@ export type IQueryCollectionArgs = {
 };
 
 
-export type IQueryCollectionFromNameAndTypeArgs = {
+export type IQueryCollectionFromNameTypeUserArgs = {
   name: Scalars['String'];
   type: ICollectionType;
+  user: Maybe<Scalars['Int']>;
 };
 
 
@@ -420,9 +425,10 @@ export type IQueryPlaylistArgs = {
 };
 
 
-export type IQueryPlaylistFromNameAndTypeArgs = {
+export type IQueryPlaylistFromNameTypeUserArgs = {
   name: Scalars['String'];
   type: IPlaylistType;
+  user: Maybe<Scalars['Int']>;
 };
 
 
@@ -2468,7 +2474,7 @@ export type ArtistsFieldPolicy = {
 	total?: FieldPolicy<any> | FieldReadFunction<any>,
 	results?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type CollectionKeySpecifier = ('id' | 'name' | 'starred' | 'type' | 'numReleases' | 'lastUpdatedOn' | 'imageId' | 'releases' | 'topGenres' | CollectionKeySpecifier)[];
+export type CollectionKeySpecifier = ('id' | 'name' | 'starred' | 'type' | 'numReleases' | 'lastUpdatedOn' | 'imageId' | 'releases' | 'topGenres' | 'user' | CollectionKeySpecifier)[];
 export type CollectionFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2478,7 +2484,8 @@ export type CollectionFieldPolicy = {
 	lastUpdatedOn?: FieldPolicy<any> | FieldReadFunction<any>,
 	imageId?: FieldPolicy<any> | FieldReadFunction<any>,
 	releases?: FieldPolicy<any> | FieldReadFunction<any>,
-	topGenres?: FieldPolicy<any> | FieldReadFunction<any>
+	topGenres?: FieldPolicy<any> | FieldReadFunction<any>,
+	user?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type CollectionAndReleaseKeySpecifier = ('collection' | 'release' | CollectionAndReleaseKeySpecifier)[];
 export type CollectionAndReleaseFieldPolicy = {
@@ -2528,7 +2535,7 @@ export type MutationFieldPolicy = {
 	addArtistToTrack?: FieldPolicy<any> | FieldReadFunction<any>,
 	delArtistFromTrack?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PlaylistKeySpecifier = ('id' | 'name' | 'starred' | 'type' | 'numTracks' | 'lastUpdatedOn' | 'imageId' | 'entries' | 'topGenres' | PlaylistKeySpecifier)[];
+export type PlaylistKeySpecifier = ('id' | 'name' | 'starred' | 'type' | 'numTracks' | 'lastUpdatedOn' | 'imageId' | 'entries' | 'topGenres' | 'user' | PlaylistKeySpecifier)[];
 export type PlaylistFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2538,7 +2545,8 @@ export type PlaylistFieldPolicy = {
 	lastUpdatedOn?: FieldPolicy<any> | FieldReadFunction<any>,
 	imageId?: FieldPolicy<any> | FieldReadFunction<any>,
 	entries?: FieldPolicy<any> | FieldReadFunction<any>,
-	topGenres?: FieldPolicy<any> | FieldReadFunction<any>
+	topGenres?: FieldPolicy<any> | FieldReadFunction<any>,
+	user?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type PlaylistAndTrackKeySpecifier = ('playlist' | 'track' | PlaylistAndTrackKeySpecifier)[];
 export type PlaylistAndTrackFieldPolicy = {
@@ -2560,7 +2568,7 @@ export type PlaylistsFieldPolicy = {
 	total?: FieldPolicy<any> | FieldReadFunction<any>,
 	results?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type QueryKeySpecifier = ('user' | 'artists' | 'artist' | 'artistFromName' | 'collections' | 'collection' | 'collectionFromNameAndType' | 'invites' | 'invite' | 'playlists' | 'playlist' | 'playlistFromNameAndType' | 'releases' | 'release' | 'tracks' | 'track' | 'releaseYears' | QueryKeySpecifier)[];
+export type QueryKeySpecifier = ('user' | 'artists' | 'artist' | 'artistFromName' | 'collections' | 'collection' | 'collectionFromNameTypeUser' | 'invites' | 'invite' | 'playlists' | 'playlist' | 'playlistFromNameTypeUser' | 'releases' | 'release' | 'tracks' | 'track' | 'releaseYears' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {
 	user?: FieldPolicy<any> | FieldReadFunction<any>,
 	artists?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2568,12 +2576,12 @@ export type QueryFieldPolicy = {
 	artistFromName?: FieldPolicy<any> | FieldReadFunction<any>,
 	collections?: FieldPolicy<any> | FieldReadFunction<any>,
 	collection?: FieldPolicy<any> | FieldReadFunction<any>,
-	collectionFromNameAndType?: FieldPolicy<any> | FieldReadFunction<any>,
+	collectionFromNameTypeUser?: FieldPolicy<any> | FieldReadFunction<any>,
 	invites?: FieldPolicy<any> | FieldReadFunction<any>,
 	invite?: FieldPolicy<any> | FieldReadFunction<any>,
 	playlists?: FieldPolicy<any> | FieldReadFunction<any>,
 	playlist?: FieldPolicy<any> | FieldReadFunction<any>,
-	playlistFromNameAndType?: FieldPolicy<any> | FieldReadFunction<any>,
+	playlistFromNameTypeUser?: FieldPolicy<any> | FieldReadFunction<any>,
 	releases?: FieldPolicy<any> | FieldReadFunction<any>,
 	release?: FieldPolicy<any> | FieldReadFunction<any>,
 	tracks?: FieldPolicy<any> | FieldReadFunction<any>,

--- a/frontend/src/graphql/index.ts
+++ b/frontend/src/graphql/index.ts
@@ -381,6 +381,7 @@ export type IQueryArtistFromNameArgs = {
 export type IQueryCollectionsArgs = {
   search: Maybe<Scalars['String']>;
   types: Maybe<Array<ICollectionType>>;
+  userIds: Maybe<Array<Scalars['Int']>>;
   page: Maybe<Scalars['Int']>;
   perPage: Maybe<Scalars['Int']>;
 };
@@ -415,6 +416,7 @@ export type IQueryInviteArgs = {
 export type IQueryPlaylistsArgs = {
   search: Maybe<Scalars['String']>;
   types: Maybe<Array<IPlaylistType>>;
+  userIds: Maybe<Array<Scalars['Int']>>;
   page: Maybe<Scalars['Int']>;
   perPage: Maybe<Scalars['Int']>;
 };

--- a/frontend/src/graphql/index.ts
+++ b/frontend/src/graphql/index.ts
@@ -591,6 +591,9 @@ export type IUser = {
   __typename?: 'User';
   id: Scalars['Int'];
   nickname: Scalars['String'];
+  inboxCollectionId: Scalars['Int'];
+  favoritesCollectionId: Scalars['Int'];
+  favoritesPlaylistId: Scalars['Int'];
 };
 
 export type IHeaderFetchUserQueryVariables = Exact<{ [key: string]: never; }>;
@@ -630,7 +633,19 @@ export type IPagedReleasesFetchReleasesQuery = (
   ) }
 );
 
+export type IFavoritePlaylistsIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type IFavoritePlaylistsIdQuery = (
+  { __typename?: 'Query' }
+  & { user: (
+    { __typename?: 'User' }
+    & Pick<IUser, 'favoritesPlaylistId'>
+  ) }
+);
+
 export type IPlaylistsFavoriteTrackMutationVariables = Exact<{
+  playlistId: Scalars['Int'];
   trackId: Scalars['Int'];
 }>;
 
@@ -979,6 +994,17 @@ export type IPlaylistsFetchTracksQuery = (
   ) }
 );
 
+export type IInFavoritesFetchFavoritesIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type IInFavoritesFetchFavoritesIdQuery = (
+  { __typename?: 'Query' }
+  & { user: (
+    { __typename?: 'User' }
+    & Pick<IUser, 'favoritesCollectionId'>
+  ) }
+);
+
 export type IInFavoritesAddReleaseToCollectionMutationVariables = Exact<{
   collectionId: Scalars['Int'];
   releaseId: Scalars['Int'];
@@ -1036,6 +1062,17 @@ export type IInFavoritesDelReleaseFromCollectionMutation = (
         & Pick<ICollection, 'id' | 'name'>
       )> }
     ) }
+  ) }
+);
+
+export type IInInboxFetchInboxIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type IInInboxFetchInboxIdQuery = (
+  { __typename?: 'Query' }
+  & { user: (
+    { __typename?: 'User' }
+    & Pick<IUser, 'inboxCollectionId'>
   ) }
 );
 
@@ -1368,9 +1405,46 @@ export type PagedReleasesFetchReleasesQueryResult = Apollo.QueryResult<IPagedRel
 export function refetchPagedReleasesFetchReleasesQuery(variables?: IPagedReleasesFetchReleasesQueryVariables) {
       return { query: PagedReleasesFetchReleasesDocument, variables: variables }
     }
+export const FavoritePlaylistsIdDocument = gql`
+    query FavoritePlaylistsId {
+  user {
+    favoritesPlaylistId
+  }
+}
+    `;
+
+/**
+ * __useFavoritePlaylistsIdQuery__
+ *
+ * To run a query within a React component, call `useFavoritePlaylistsIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFavoritePlaylistsIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFavoritePlaylistsIdQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useFavoritePlaylistsIdQuery(baseOptions?: Apollo.QueryHookOptions<IFavoritePlaylistsIdQuery, IFavoritePlaylistsIdQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<IFavoritePlaylistsIdQuery, IFavoritePlaylistsIdQueryVariables>(FavoritePlaylistsIdDocument, options);
+      }
+export function useFavoritePlaylistsIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<IFavoritePlaylistsIdQuery, IFavoritePlaylistsIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<IFavoritePlaylistsIdQuery, IFavoritePlaylistsIdQueryVariables>(FavoritePlaylistsIdDocument, options);
+        }
+export type FavoritePlaylistsIdQueryHookResult = ReturnType<typeof useFavoritePlaylistsIdQuery>;
+export type FavoritePlaylistsIdLazyQueryHookResult = ReturnType<typeof useFavoritePlaylistsIdLazyQuery>;
+export type FavoritePlaylistsIdQueryResult = Apollo.QueryResult<IFavoritePlaylistsIdQuery, IFavoritePlaylistsIdQueryVariables>;
+export function refetchFavoritePlaylistsIdQuery(variables?: IFavoritePlaylistsIdQueryVariables) {
+      return { query: FavoritePlaylistsIdDocument, variables: variables }
+    }
 export const PlaylistsFavoriteTrackDocument = gql`
-    mutation PlaylistsFavoriteTrack($trackId: Int!) {
-  createPlaylistEntry(playlistId: 1, trackId: $trackId) {
+    mutation PlaylistsFavoriteTrack($playlistId: Int!, $trackId: Int!) {
+  createPlaylistEntry(playlistId: $playlistId, trackId: $trackId) {
     id
     playlist {
       id
@@ -1401,6 +1475,7 @@ export type IPlaylistsFavoriteTrackMutationFn = Apollo.MutationFunction<IPlaylis
  * @example
  * const [playlistsFavoriteTrackMutation, { data, loading, error }] = usePlaylistsFavoriteTrackMutation({
  *   variables: {
+ *      playlistId: // value for 'playlistId'
  *      trackId: // value for 'trackId'
  *   },
  * });
@@ -2062,6 +2137,43 @@ export type PlaylistsFetchTracksQueryResult = Apollo.QueryResult<IPlaylistsFetch
 export function refetchPlaylistsFetchTracksQuery(variables?: IPlaylistsFetchTracksQueryVariables) {
       return { query: PlaylistsFetchTracksDocument, variables: variables }
     }
+export const InFavoritesFetchFavoritesIdDocument = gql`
+    query InFavoritesFetchFavoritesId {
+  user {
+    favoritesCollectionId
+  }
+}
+    `;
+
+/**
+ * __useInFavoritesFetchFavoritesIdQuery__
+ *
+ * To run a query within a React component, call `useInFavoritesFetchFavoritesIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useInFavoritesFetchFavoritesIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useInFavoritesFetchFavoritesIdQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useInFavoritesFetchFavoritesIdQuery(baseOptions?: Apollo.QueryHookOptions<IInFavoritesFetchFavoritesIdQuery, IInFavoritesFetchFavoritesIdQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<IInFavoritesFetchFavoritesIdQuery, IInFavoritesFetchFavoritesIdQueryVariables>(InFavoritesFetchFavoritesIdDocument, options);
+      }
+export function useInFavoritesFetchFavoritesIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<IInFavoritesFetchFavoritesIdQuery, IInFavoritesFetchFavoritesIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<IInFavoritesFetchFavoritesIdQuery, IInFavoritesFetchFavoritesIdQueryVariables>(InFavoritesFetchFavoritesIdDocument, options);
+        }
+export type InFavoritesFetchFavoritesIdQueryHookResult = ReturnType<typeof useInFavoritesFetchFavoritesIdQuery>;
+export type InFavoritesFetchFavoritesIdLazyQueryHookResult = ReturnType<typeof useInFavoritesFetchFavoritesIdLazyQuery>;
+export type InFavoritesFetchFavoritesIdQueryResult = Apollo.QueryResult<IInFavoritesFetchFavoritesIdQuery, IInFavoritesFetchFavoritesIdQueryVariables>;
+export function refetchInFavoritesFetchFavoritesIdQuery(variables?: IInFavoritesFetchFavoritesIdQueryVariables) {
+      return { query: InFavoritesFetchFavoritesIdDocument, variables: variables }
+    }
 export const InFavoritesAddReleaseToCollectionDocument = gql`
     mutation InFavoritesAddReleaseToCollection($collectionId: Int!, $releaseId: Int!) {
   addReleaseToCollection(collectionId: $collectionId, releaseId: $releaseId) {
@@ -2172,6 +2284,43 @@ export function useInFavoritesDelReleaseFromCollectionMutation(baseOptions?: Apo
 export type InFavoritesDelReleaseFromCollectionMutationHookResult = ReturnType<typeof useInFavoritesDelReleaseFromCollectionMutation>;
 export type InFavoritesDelReleaseFromCollectionMutationResult = Apollo.MutationResult<IInFavoritesDelReleaseFromCollectionMutation>;
 export type InFavoritesDelReleaseFromCollectionMutationOptions = Apollo.BaseMutationOptions<IInFavoritesDelReleaseFromCollectionMutation, IInFavoritesDelReleaseFromCollectionMutationVariables>;
+export const InInboxFetchInboxIdDocument = gql`
+    query InInboxFetchInboxId {
+  user {
+    inboxCollectionId
+  }
+}
+    `;
+
+/**
+ * __useInInboxFetchInboxIdQuery__
+ *
+ * To run a query within a React component, call `useInInboxFetchInboxIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useInInboxFetchInboxIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useInInboxFetchInboxIdQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useInInboxFetchInboxIdQuery(baseOptions?: Apollo.QueryHookOptions<IInInboxFetchInboxIdQuery, IInInboxFetchInboxIdQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<IInInboxFetchInboxIdQuery, IInInboxFetchInboxIdQueryVariables>(InInboxFetchInboxIdDocument, options);
+      }
+export function useInInboxFetchInboxIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<IInInboxFetchInboxIdQuery, IInInboxFetchInboxIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<IInInboxFetchInboxIdQuery, IInInboxFetchInboxIdQueryVariables>(InInboxFetchInboxIdDocument, options);
+        }
+export type InInboxFetchInboxIdQueryHookResult = ReturnType<typeof useInInboxFetchInboxIdQuery>;
+export type InInboxFetchInboxIdLazyQueryHookResult = ReturnType<typeof useInInboxFetchInboxIdLazyQuery>;
+export type InInboxFetchInboxIdQueryResult = Apollo.QueryResult<IInInboxFetchInboxIdQuery, IInInboxFetchInboxIdQueryVariables>;
+export function refetchInInboxFetchInboxIdQuery(variables?: IInInboxFetchInboxIdQueryVariables) {
+      return { query: InInboxFetchInboxIdDocument, variables: variables }
+    }
 export const InInboxAddReleaseToCollectionDocument = gql`
     mutation InInboxAddReleaseToCollection($collectionId: Int!, $releaseId: Int!) {
   addReleaseToCollection(collectionId: $collectionId, releaseId: $releaseId) {
@@ -2655,10 +2804,13 @@ export type TracksFieldPolicy = {
 	total?: FieldPolicy<any> | FieldReadFunction<any>,
 	results?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type UserKeySpecifier = ('id' | 'nickname' | UserKeySpecifier)[];
+export type UserKeySpecifier = ('id' | 'nickname' | 'inboxCollectionId' | 'favoritesCollectionId' | 'favoritesPlaylistId' | UserKeySpecifier)[];
 export type UserFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	nickname?: FieldPolicy<any> | FieldReadFunction<any>
+	nickname?: FieldPolicy<any> | FieldReadFunction<any>,
+	inboxCollectionId?: FieldPolicy<any> | FieldReadFunction<any>,
+	favoritesCollectionId?: FieldPolicy<any> | FieldReadFunction<any>,
+	favoritesPlaylistId?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type TypedTypePolicies = TypePolicies & {
 	Artist?: Omit<TypePolicy, "fields" | "keyFields"> & {

--- a/frontend/src/graphql/index.ts
+++ b/frontend/src/graphql/index.ts
@@ -553,7 +553,7 @@ export type ITrack = {
   trackNumber: Scalars['String'];
   discNumber: Scalars['String'];
   /** Whether the track is in the user's favorites playlist. */
-  favorited: Scalars['Boolean'];
+  inFavorites: Scalars['Boolean'];
   release: IRelease;
   artists: Array<ITrackArtist>;
 };
@@ -649,7 +649,7 @@ export type IPlaylistsFavoriteTrackMutation = (
       )> }
     ), track: (
       { __typename?: 'Track' }
-      & Pick<ITrack, 'id' | 'favorited'>
+      & Pick<ITrack, 'id' | 'inFavorites'>
     ) }
   ) }
 );
@@ -672,7 +672,7 @@ export type IPlaylistsUnfavoriteTrackMutation = (
       )> }
     ), track: (
       { __typename?: 'Track' }
-      & Pick<ITrack, 'id' | 'favorited'>
+      & Pick<ITrack, 'id' | 'inFavorites'>
     ) }
   ) }
 );
@@ -753,7 +753,7 @@ export type IPlaylistFieldsFragment = (
 
 export type ITrackFieldsFragment = (
   { __typename?: 'Track' }
-  & Pick<ITrack, 'id' | 'title' | 'duration' | 'trackNumber' | 'discNumber' | 'favorited'>
+  & Pick<ITrack, 'id' | 'title' | 'duration' | 'trackNumber' | 'discNumber' | 'inFavorites'>
   & { release: (
     { __typename?: 'Release' }
     & Pick<IRelease, 'id' | 'imageId'>
@@ -1239,7 +1239,7 @@ export const TrackFieldsFragmentDoc = gql`
   duration
   trackNumber
   discNumber
-  favorited
+  inFavorites
   release {
     id
     imageId
@@ -1381,7 +1381,7 @@ export const PlaylistsFavoriteTrackDocument = gql`
     }
     track {
       id
-      favorited
+      inFavorites
     }
   }
 }
@@ -1424,7 +1424,7 @@ export const PlaylistsUnfavoriteTrackDocument = gql`
     }
     track {
       id
-      favorited
+      inFavorites
     }
   }
 }
@@ -2629,14 +2629,14 @@ export type TopGenreFieldPolicy = {
 	genre?: FieldPolicy<any> | FieldReadFunction<any>,
 	numMatches?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type TrackKeySpecifier = ('id' | 'title' | 'duration' | 'trackNumber' | 'discNumber' | 'favorited' | 'release' | 'artists' | TrackKeySpecifier)[];
+export type TrackKeySpecifier = ('id' | 'title' | 'duration' | 'trackNumber' | 'discNumber' | 'inFavorites' | 'release' | 'artists' | TrackKeySpecifier)[];
 export type TrackFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	title?: FieldPolicy<any> | FieldReadFunction<any>,
 	duration?: FieldPolicy<any> | FieldReadFunction<any>,
 	trackNumber?: FieldPolicy<any> | FieldReadFunction<any>,
 	discNumber?: FieldPolicy<any> | FieldReadFunction<any>,
-	favorited?: FieldPolicy<any> | FieldReadFunction<any>,
+	inFavorites?: FieldPolicy<any> | FieldReadFunction<any>,
 	release?: FieldPolicy<any> | FieldReadFunction<any>,
 	artists?: FieldPolicy<any> | FieldReadFunction<any>
 };

--- a/frontend/src/graphql/index.ts
+++ b/frontend/src/graphql/index.ts
@@ -71,6 +71,7 @@ export type ICollectionAndRelease = {
 
 export enum ICollectionType {
   System = 'SYSTEM',
+  Personal = 'PERSONAL',
   Collage = 'COLLAGE',
   Label = 'LABEL',
   Genre = 'GENRE'
@@ -304,6 +305,7 @@ export type IPlaylistEntry = {
 
 export enum IPlaylistType {
   System = 'SYSTEM',
+  Personal = 'PERSONAL',
   Playlist = 'PLAYLIST'
 }
 

--- a/frontend/src/pages/Invites/Invite.tsx
+++ b/frontend/src/pages/Invites/Invite.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { useToasts } from 'react-toast-notifications';
 
 import { Icon, ListItem } from '~/components';
-import { IInvite } from '~/graphql';
+import { IInviteFieldsFragment } from '~/graphql';
 import { timeUntil } from '~/util';
 
 const SECONDS_IN_DAY = 24 * 60 * 60;
 
 type IInviteComponent = React.FC<
-  Pick<IInvite, 'id' | 'createdAt' | 'code' | 'createdBy'>
+  Pick<IInviteFieldsFragment, 'id' | 'createdAt' | 'code' | 'createdBy'>
 >;
 
 export const Invite: IInviteComponent = ({ id, createdAt, code, createdBy }) => {

--- a/frontend/src/pages/Invites/index.tsx
+++ b/frontend/src/pages/Invites/index.tsx
@@ -31,6 +31,7 @@ export const Invites: React.FC = () => {
         <div tw="pb-8 text-foreground-400">Click an invite to copy its invite URL.</div>
         <div tw="flex">
           <div tw="flex-shrink">
+            {/* TODO: Loading animation */}
             {invites.map((inv) => (
               <Invite key={inv.id} {...inv} />
             ))}


### PR DESCRIPTION
Closes #155 

Changes:
- [x] Add a personal collection/playlist type to the database.
- [x] Associate a user ID with a collection/playlist, enforce that this must be non-null for system & personal and null otherwise.
- [x] Conditionally fetch playlists/collections that belong to the user (system & personal types) with `of_user` kwarg (this only affects the collection & playlist types.
- [x] Create user inbox/favorites on user creation.
- [x] Patch all the logic that assumes a constant ID for inbox & favorites.
- [x] Add all releases into user inbox on user creation.
- [ ] Prefix system and personal collections with a user's nickname on frontend.

Future work:
- Can add feature to fetch all playlists/collections. Requires the ability to fetch nicknames for all other users. 